### PR TITLE
✨ feat(examples): 新增网络相关示例

### DIFF
--- a/components/xf_net_apps/XFKconfig
+++ b/components/xf_net_apps/XFKconfig
@@ -1,0 +1,19 @@
+
+menu "xf_net_apps Configuration"
+
+    config XF_NET_APPS_ENABLE
+        bool "Enable xf_net_apps module."
+        default y
+
+    config XF_NET_APPS_IPERF_ENABLE
+        bool "Enable iperf."
+        default y
+        depends on XF_NET_APPS_ENABLE
+
+    config XF_NET_APPS_PING_ENABLE
+        bool "Enable ping."
+        default y
+        depends on XF_NET_APPS_ENABLE
+
+endmenu # xf_net_apps Configuration
+  

--- a/components/xf_net_apps/xf_collect.py
+++ b/components/xf_net_apps/xf_collect.py
@@ -1,0 +1,27 @@
+import xf_build
+
+srcs = [
+    "*.c",
+]
+
+incs = [
+    ".",
+]
+
+reqs = [
+    "xf_utils",
+    "xf_osal",
+    "xf_sys",
+]
+
+apps_enabled = xf_build.get_define("XF_NET_APPS_ENABLE")
+if apps_enabled == "y":
+    if xf_build.get_define("XF_NET_APPS_IPERF_ENABLE") == "y":
+        srcs.append("xf_iperf/*.c")
+        incs.append("xf_iperf")
+    if xf_build.get_define("XF_NET_APPS_PING_ENABLE") == "y":
+        srcs.append("xf_ping/*.c")
+        incs.append("xf_ping")
+    xf_build.collect(srcs=srcs, inc_dirs=incs, requires=reqs)
+else:
+    xf_build.collect()

--- a/components/xf_net_apps/xf_iperf/xf_iperf.c
+++ b/components/xf_net_apps/xf_iperf/xf_iperf.c
@@ -1,0 +1,684 @@
+/**
+ * @file xf_iperf.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-09-26
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* Iperf Example - iperf implementation
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+/* ==================== [Includes] ========================================== */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/param.h>
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/netdb.h"
+
+#include "xf_utils.h"
+#include "xf_netif.h"
+#include "xf_osal.h"
+#include "xf_sys.h"
+
+#include "xf_iperf.h"
+
+/* ==================== [Defines] =========================================== */
+
+#define IPERF_HUNDRED          100
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static inline bool iperf_is_udp_client(void);
+static inline bool iperf_is_udp_server(void);
+static inline bool iperf_is_tcp_client(void);
+static inline bool iperf_is_tcp_server(void);
+static int iperf_get_socket_error_code(int sockfd);
+static int iperf_show_socket_error_reason(const char *str, int sockfd);
+static void iperf_report_task(void *arg);
+static xf_err_t iperf_start_report(void);
+static void socket_recv(int recv_socket, struct sockaddr *listen_addr, uint8_t type);
+static void socket_send(int send_socket, struct sockaddr *dest_addr, uint8_t type, int bw_lim);
+static xf_err_t iperf_run_tcp_server(void);
+static xf_err_t iperf_run_tcp_client(void);
+static xf_err_t iperf_run_udp_server(void);
+static xf_err_t iperf_run_udp_client(void);
+static void iperf_task_traffic(void *arg);
+static uint32_t iperf_get_buffer_len(void);
+static uint32_t iperf_get_float_int(float in);
+static uint32_t iperf_get_float_dec(float in);
+
+/* ==================== [Static Variables] ================================== */
+
+static xf_iperf_ctx_t s_ctx;
+static const char *TAG = "iperf";
+
+/* ==================== [Macros] ============================================ */
+
+#define XF_ASSERT_RET_GOTO(condition, err_code, label, tag, format, ...) \
+    do { \
+        ret = err_code; \
+        XF_ASSERT_GOTO(condition, label, tag, format, ##__VA_ARGS__); \
+    } while (0)
+
+/* ==================== [Global Functions] ================================== */
+
+xf_err_t xf_iperf_start(
+    const xf_iperf_cfg_t *p_cfg, xf_iperf_cb_t cb_func, void *user_args)
+{
+    if (!p_cfg) {
+        return XF_FAIL;
+    }
+
+    if (s_ctx.traffic_is_running) {
+        XF_LOGW(TAG, "iperf is running");
+        return XF_FAIL;
+    }
+
+    xf_memset(&s_ctx, 0, sizeof(s_ctx));
+    xf_memcpy(&s_ctx.cfg, p_cfg, sizeof(*p_cfg));
+    s_ctx.traffic_is_running    = true;
+    s_ctx.finish                = false;
+    s_ctx.buffer_len            = iperf_get_buffer_len();
+    s_ctx.buffer                = (uint8_t *)xf_malloc(s_ctx.buffer_len);
+    if (!s_ctx.buffer) {
+        XF_LOGE(TAG, "create buffer: not enough memory");
+        return XF_FAIL;
+    }
+    xf_memset(s_ctx.buffer, 0, s_ctx.buffer_len);
+
+    s_ctx.cb_func         = cb_func;
+    s_ctx.user_args       = user_args;
+
+    /* socket 成功通信后再创建 report_task */
+
+    xf_osal_thread_attr_t thread_attr = {
+        .name       = IPERF_TRAFFIC_TASK_NAME,
+        .priority   = p_cfg->traffic_task_prio,
+        .stack_size = p_cfg->traffic_task_stack_size,
+    };
+    s_ctx.traffic_task_hdl =
+        xf_osal_thread_create(iperf_task_traffic, NULL, &thread_attr);
+    if (s_ctx.traffic_task_hdl == NULL) {
+        XF_LOGE(TAG, "create task %s failed", IPERF_TRAFFIC_TASK_NAME);
+        xf_free(s_ctx.buffer);
+        s_ctx.buffer = NULL;
+        return XF_FAIL;
+    }
+    return XF_OK;
+}
+
+xf_err_t xf_iperf_stop(void)
+{
+    if (s_ctx.traffic_is_running) {
+        s_ctx.finish = true;
+    }
+
+    while (s_ctx.traffic_is_running || s_ctx.report_is_running) {
+        XF_LOGI(TAG, "wait current iperf to stop ...");
+        xf_osal_delay_ms(100);
+    }
+
+    return XF_OK;
+}
+
+bool xf_iperf_is_running(void)
+{
+    return s_ctx.traffic_is_running;
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static inline bool iperf_is_udp_client(void)
+{
+    return ((s_ctx.cfg.flag & IPERF_FLAG_CLIENT)
+            && (s_ctx.cfg.flag & IPERF_FLAG_UDP));
+}
+
+static inline bool iperf_is_udp_server(void)
+{
+    return ((s_ctx.cfg.flag & IPERF_FLAG_SERVER)
+            && (s_ctx.cfg.flag & IPERF_FLAG_UDP));
+}
+
+static inline bool iperf_is_tcp_client(void)
+{
+    return ((s_ctx.cfg.flag & IPERF_FLAG_CLIENT)
+            && (s_ctx.cfg.flag & IPERF_FLAG_TCP));
+}
+
+static inline bool iperf_is_tcp_server(void)
+{
+    return ((s_ctx.cfg.flag & IPERF_FLAG_SERVER)
+            && (s_ctx.cfg.flag & IPERF_FLAG_TCP));
+}
+
+static int iperf_get_socket_error_code(int sockfd)
+{
+    return errno;
+}
+
+static int iperf_show_socket_error_reason(const char *str, int sockfd)
+{
+    int err = errno;
+    if (err != 0) {
+        XF_LOGW(TAG, "%s error, error code: %d, reason: %s",
+                str, err, strerror(err));
+    }
+
+    return err;
+}
+
+static void iperf_report_task(void *arg)
+{
+    UNUSED(arg);
+    s_ctx.report_is_running = true;
+
+    uint32_t interval = s_ctx.cfg.interval;
+    uint32_t time = s_ctx.cfg.time;
+    uint32_t delay_interval_ms = interval * 1000;
+    uint32_t cur = 0;
+    float average = 0;
+    float actual_bandwidth = 0;
+    int k = 1;
+
+    if (s_ctx.cb_func) {
+        s_ctx.cb_func(XF_IPERF_EVENT_REPORT, &s_ctx, s_ctx.user_args);
+    }
+    if (s_ctx.cfg.report_enabled) {
+        xf_printf("\n%16s %s\n", "Interval", "Bandwidth");
+    }
+
+    while (!s_ctx.finish) {
+        xf_osal_delay_ms(delay_interval_ms);
+
+        /* 更新本次带宽 */
+        s_ctx.actual_len = s_ctx.actual_len_internal;
+        actual_bandwidth = ((float)(s_ctx.actual_len * 8) / 1e6f) / (float)interval;
+        s_ctx.actual_bandwidth = actual_bandwidth;
+
+        /* 更新平均带宽 */
+        average = ((average * (k - 1) / k) + (actual_bandwidth / k));
+        s_ctx.average_bandwidth = average;
+
+        /* 更新报告时刻 */
+        s_ctx.curr_time = cur;
+
+        if (s_ctx.cb_func) {
+            s_ctx.cb_func(XF_IPERF_EVENT_REPORT, &s_ctx, s_ctx.user_args);
+        }
+        if (s_ctx.cfg.report_enabled) {
+            xf_printf("%4d-%4d sec       %d.%02d Mbits/sec\n",
+                      cur, cur + interval,
+                      iperf_get_float_int(actual_bandwidth),
+                      iperf_get_float_dec(actual_bandwidth));
+        }
+
+        cur += interval;
+        k++;
+        s_ctx.actual_len_internal = 0;
+
+        if (cur >= time) {
+            s_ctx.finish = true;
+            break;
+        }
+    }
+
+    s_ctx.finish = true;
+
+    if (s_ctx.cb_func) {
+        s_ctx.cb_func(XF_IPERF_EVENT_END, &s_ctx, s_ctx.user_args);
+    }
+    if (s_ctx.cfg.report_enabled) {
+        xf_printf("%4d-%4d sec       %d.%02d Mbits/sec\n",
+                  0, time,
+                  iperf_get_float_int(average),
+                  iperf_get_float_dec(average));
+    }
+
+    s_ctx.report_is_running = false;
+    xf_osal_thread_delete(NULL);
+}
+
+static xf_err_t iperf_start_report(void)
+{
+    xf_osal_thread_attr_t thread_attr = {
+        .name       = IPERF_REPORT_TASK_NAME,
+        .priority   = s_ctx.cfg.report_task_prio,
+        .stack_size = s_ctx.cfg.report_task_stack_size,
+    };
+    s_ctx.report_task_hdl = xf_osal_thread_create(iperf_report_task, NULL, &thread_attr);
+    if (s_ctx.report_task_hdl == NULL) {
+        XF_LOGE(TAG, "create task %s failed", IPERF_REPORT_TASK_NAME);
+        s_ctx.finish = true;
+        return XF_FAIL;
+    }
+    return XF_OK;
+}
+
+static void socket_recv(int recv_socket, struct sockaddr *listen_addr, uint8_t type)
+{
+    bool iperf_recv_start = true;
+    uint8_t *buffer;
+    int want_recv = 0;
+    int actual_recv = 0;
+    socklen_t socklen = (s_ctx.cfg.type == IPERF_IP_TYPE_IPV6)
+                        ? sizeof(struct sockaddr_in6)
+                        : sizeof(struct sockaddr_in);
+    const char *error_log = (type == IPERF_TRANS_TYPE_TCP)
+                            ? "tcp server recv"
+                            : "udp server recv";
+
+    s_ctx.actual_len_internal = 0;
+
+    buffer      = s_ctx.buffer;
+    want_recv   = s_ctx.buffer_len;
+    while (!s_ctx.finish) {
+        actual_recv = recvfrom(recv_socket, buffer, want_recv, 0, listen_addr, &socklen);
+        if (actual_recv >= 0) {
+            if (iperf_recv_start) {
+                iperf_start_report();
+                iperf_recv_start = false;
+            }
+            s_ctx.actual_len_internal += actual_recv;
+        } else if (type == IPERF_TRANS_TYPE_TCP) { /* UDP 时不判断接收错误 */
+            iperf_show_socket_error_reason(error_log, recv_socket);
+            s_ctx.finish = true;
+            break;
+        }
+
+    }
+}
+
+static void socket_send(int send_socket, struct sockaddr *dest_addr, uint8_t type, int bw_lim)
+{
+    uint8_t *buffer;
+    uint32_t *pkt_id_p;
+    uint32_t pkt_cnt = 0;
+    int actual_send = 0;
+    int want_send = 0;
+    int period_us = -1;
+    int delay_us = 0;
+    xf_us_t prev_time = 0;
+    xf_us_t send_time = 0;
+    int err = 0;
+    const socklen_t socklen = (s_ctx.cfg.type == IPERF_IP_TYPE_IPV6)
+                              ? sizeof(struct sockaddr_in6)
+                              : sizeof(struct sockaddr_in);
+    const char *error_log = (type == IPERF_TRANS_TYPE_TCP)
+                            ? "tcp client send"
+                            : "udp client send";
+
+    buffer = s_ctx.buffer;
+    pkt_id_p = (uint32_t *)s_ctx.buffer;
+    want_send = s_ctx.buffer_len;
+    iperf_start_report();
+
+    if (bw_lim > 0) {
+        period_us = want_send * 8 / bw_lim;
+    }
+
+    while (!s_ctx.finish) {
+        if (period_us > 0) {
+            send_time = xf_sys_time_get_us();
+            if (actual_send > 0) {
+                // Last packet "send" was successful, check how much off the previous loop duration was to the ideal send period. Result will adjust the
+                // next send delay.
+                delay_us += period_us + (int32_t)(prev_time - send_time);
+            } else {
+                // Last packet "send" was not successful. Ideally we should try to catch up the whole previous loop duration (e.g. prev_time - send_time).
+                // However, that's not possible since the most probable reason why the send was unsuccessful is the HW was not able to process the packet.
+                // Hence, we cannot queue more packets with shorter (or no) delay to catch up since we are already at the performance edge. The best we
+                // can do is to reset the send delay (which is probably big negative number) and start all over again.
+                delay_us = 0;
+            }
+            prev_time = send_time;
+        }
+        *pkt_id_p = htonl(pkt_cnt++); // datagrams need to be sequentially numbered
+        actual_send = sendto(send_socket, buffer, want_send, 0, dest_addr, socklen);
+        if (actual_send != want_send) {
+            if (type == IPERF_TRANS_TYPE_UDP) {
+                err = iperf_get_socket_error_code(send_socket);
+                // ENOMEM is expected under heavy load => do not print it
+                if (err != ENOMEM) {
+                    iperf_show_socket_error_reason(error_log, send_socket);
+                }
+            } else if (type == IPERF_TRANS_TYPE_TCP) {
+                iperf_show_socket_error_reason(error_log, send_socket);
+                break;
+            }
+        } else {
+            s_ctx.actual_len_internal += actual_send;
+        }
+        // The send delay may be negative, it indicates we are trying to catch up and hence to not delay the loop at all.
+        if (delay_us > 0) {
+            xf_delay_us(delay_us);
+        }
+    }
+}
+
+static xf_err_t iperf_run_tcp_server(void)
+{
+    int listen_socket = -1;
+    int client_socket = -1;
+    int opt = 1;
+    int err = 0;
+    xf_err_t ret = XF_OK;
+    struct sockaddr_in remote_addr;
+    struct timeval timeout = { 0 };
+    socklen_t addr_len = sizeof(struct sockaddr);
+    struct sockaddr *listen_addr = NULL;
+    struct sockaddr_in6 listen_addr6 = { 0 };
+    struct sockaddr_in listen_addr4 = { 0 };
+
+    XF_ASSERT_RET_GOTO((s_ctx.cfg.type == IPERF_IP_TYPE_IPV6 || s_ctx.cfg.type == IPERF_IP_TYPE_IPV4),
+                       XF_FAIL, l_exit, TAG, "Ivalid AF types");
+
+    if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV6) {
+        // The TCP server listen at the address "::", which means all addresses can be listened to.
+        inet6_aton("::", &listen_addr6.sin6_addr);
+        listen_addr6.sin6_family = AF_INET6;
+        listen_addr6.sin6_port = htons(s_ctx.cfg.sport);
+
+        listen_socket = socket(AF_INET6, SOCK_STREAM, IPPROTO_IPV6);
+        XF_ASSERT_RET_GOTO((listen_socket >= 0), XF_FAIL, l_exit, TAG, "Unable to create socket: errno %d", errno);
+
+        setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+        setsockopt(listen_socket, IPPROTO_IPV6, IPV6_V6ONLY, &opt, sizeof(opt));
+
+        XF_LOGI(TAG, "Socket created");
+
+        err = bind(listen_socket, (struct sockaddr *)&listen_addr6, sizeof(listen_addr6));
+        XF_ASSERT_RET_GOTO((err == 0), XF_FAIL, l_exit, TAG, "Socket unable to bind: errno %d, IPPROTO: %d", errno, AF_INET6);
+        err = listen(listen_socket, 1);
+        XF_ASSERT_RET_GOTO((err == 0), XF_FAIL, l_exit, TAG, "Error occurred during listen: errno %d", errno);
+
+        timeout.tv_sec  = IPERF_SOCKET_RX_TIMEOUT_MS / 1000;
+        timeout.tv_usec = (IPERF_SOCKET_RX_TIMEOUT_MS % 1000) * 1000;
+        setsockopt(listen_socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+        listen_addr = (struct sockaddr *)&listen_addr6;
+    } else if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV4) {
+        listen_addr4.sin_family = AF_INET;
+        listen_addr4.sin_port = htons(s_ctx.cfg.sport);
+        listen_addr4.sin_addr.s_addr = s_ctx.cfg.source_ip4;
+
+        listen_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        XF_ASSERT_RET_GOTO((listen_socket >= 0), XF_FAIL, l_exit, TAG, "Unable to create socket: errno %d", errno);
+
+        setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        XF_LOGI(TAG, "Socket created");
+
+        err = bind(listen_socket, (struct sockaddr *)&listen_addr4, sizeof(listen_addr4));
+        XF_ASSERT_RET_GOTO((err == 0), XF_FAIL, l_exit, TAG, "Socket unable to bind: errno %d, IPPROTO: %d", errno, AF_INET);
+
+        err = listen(listen_socket, 5);
+        XF_ASSERT_RET_GOTO((err == 0), XF_FAIL, l_exit, TAG, "Error occurred during listen: errno %d", errno);
+
+        listen_addr = (struct sockaddr *)&listen_addr4;
+    }
+
+    client_socket = accept(listen_socket, (struct sockaddr *)&remote_addr, &addr_len);
+    XF_ASSERT_RET_GOTO((client_socket >= 0), XF_FAIL, l_exit, TAG, "Unable to accept connection: errno %d", errno);
+    XF_LOGI(TAG, "accept: %s,%d\n", inet_ntoa(remote_addr.sin_addr), htons(remote_addr.sin_port));
+
+    timeout.tv_sec  = IPERF_SOCKET_RX_TIMEOUT_MS / 1000;
+    timeout.tv_usec = (IPERF_SOCKET_RX_TIMEOUT_MS % 1000) * 1000;
+    setsockopt(client_socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+    socket_recv(client_socket, listen_addr, IPERF_TRANS_TYPE_TCP);
+l_exit:
+    if (client_socket != -1) {
+        shutdown(client_socket, SHUT_RDWR);
+        closesocket(client_socket);
+    }
+
+    if (listen_socket != -1) {
+        shutdown(listen_socket, SHUT_RDWR);
+        closesocket(listen_socket);
+        XF_LOGI(TAG, "TCP Socket server is closed.");
+    }
+    s_ctx.finish = true;
+    return ret;
+}
+
+static xf_err_t iperf_run_tcp_client(void)
+{
+    int client_socket = -1;
+    int err = 0;
+    xf_err_t ret = XF_OK;
+    struct sockaddr *dest_addr = NULL;
+    struct sockaddr_in6 dest_addr6 = { 0 };
+    struct sockaddr_in dest_addr4 = { 0 };
+
+    XF_ASSERT_RET_GOTO((s_ctx.cfg.type == IPERF_IP_TYPE_IPV6 || s_ctx.cfg.type == IPERF_IP_TYPE_IPV4),
+                       XF_FAIL, l_exit, TAG, "Ivalid AF types");
+
+    if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV6) {
+        client_socket = socket(AF_INET6, SOCK_STREAM, IPPROTO_IPV6);
+        XF_ASSERT_RET_GOTO((client_socket >= 0), XF_FAIL, l_exit, TAG, "Unable to create socket: errno %d", errno);
+
+        inet6_aton(s_ctx.cfg.destination_ip6, &dest_addr6.sin6_addr);
+        dest_addr6.sin6_family = AF_INET6;
+        dest_addr6.sin6_port = htons(s_ctx.cfg.dport);
+
+        err = connect(client_socket, (struct sockaddr *)&dest_addr6, sizeof(struct sockaddr_in6));
+        XF_ASSERT_RET_GOTO((err == 0), XF_FAIL, l_exit, TAG, "Socket unable to connect: errno %d", errno);
+        XF_LOGI(TAG, "Successfully connected");
+
+        dest_addr = (struct sockaddr *)&dest_addr6;
+    } else if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV4) {
+        client_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        XF_ASSERT_RET_GOTO((client_socket >= 0), XF_FAIL, l_exit, TAG, "Unable to create socket: errno %d", errno);
+
+        dest_addr4.sin_family = AF_INET;
+        dest_addr4.sin_port = htons(s_ctx.cfg.dport);
+        dest_addr4.sin_addr.s_addr = s_ctx.cfg.destination_ip4;
+
+        err = connect(client_socket, (struct sockaddr *)&dest_addr4, sizeof(struct sockaddr_in));
+        XF_ASSERT_RET_GOTO((err == 0), XF_FAIL, l_exit, TAG, "Socket unable to connect: errno %d", errno);
+        XF_LOGI(TAG, "Successfully connected");
+
+        dest_addr = (struct sockaddr *)&dest_addr4;
+    }
+
+    socket_send(client_socket, dest_addr, IPERF_TRANS_TYPE_TCP, s_ctx.cfg.bw_lim);
+l_exit:
+    if (client_socket != -1) {
+        shutdown(client_socket, SHUT_RDWR);
+        closesocket(client_socket);
+        XF_LOGI(TAG, "TCP Socket client is closed.");
+    }
+    s_ctx.finish = true;
+    return ret;
+}
+
+static xf_err_t iperf_run_udp_server(void)
+{
+    int listen_socket = -1;
+    int opt = 1;
+    int err = 0;
+    xf_err_t ret = XF_OK;
+    struct timeval timeout = { 0 };
+    struct sockaddr *listen_addr = NULL;
+    struct sockaddr_in6 listen_addr6 = { 0 };
+    struct sockaddr_in listen_addr4 = { 0 };
+
+    XF_ASSERT_RET_GOTO((s_ctx.cfg.type == IPERF_IP_TYPE_IPV6 || s_ctx.cfg.type == IPERF_IP_TYPE_IPV4),
+                       XF_FAIL, l_exit, TAG, "Ivalid AF types");
+
+    if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV6) {
+        // The UDP server listen at the address "::", which means all addresses can be listened to.
+        inet6_aton("::", &listen_addr6.sin6_addr);
+        listen_addr6.sin6_family = AF_INET6;
+        listen_addr6.sin6_port = htons(s_ctx.cfg.sport);
+
+        listen_socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+        XF_ASSERT_RET_GOTO((listen_socket >= 0), XF_FAIL, l_exit, TAG, "Unable to create socket: errno %d", errno);
+        XF_LOGI(TAG, "Socket created");
+
+        setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        err = bind(listen_socket, (struct sockaddr *)&listen_addr6, sizeof(struct sockaddr_in6));
+        XF_ASSERT_RET_GOTO((err == 0), XF_FAIL, l_exit, TAG, "Socket unable to bind: errno %d", errno);
+        XF_LOGI(TAG, "Socket bound, port %d", listen_addr6.sin6_port);
+
+        listen_addr = (struct sockaddr *)&listen_addr6;
+    } else if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV4) {
+        listen_addr4.sin_family = AF_INET;
+        listen_addr4.sin_port = htons(s_ctx.cfg.sport);
+        listen_addr4.sin_addr.s_addr = s_ctx.cfg.source_ip4;
+
+        listen_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+        XF_ASSERT_RET_GOTO((listen_socket >= 0), XF_FAIL, l_exit, TAG, "Unable to create socket: errno %d", errno);
+        XF_LOGI(TAG, "Socket created");
+
+        setsockopt(listen_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        err = bind(listen_socket, (struct sockaddr *)&listen_addr4, sizeof(struct sockaddr_in));
+        XF_ASSERT_RET_GOTO((err == 0), XF_FAIL, l_exit, TAG, "Socket unable to bind: errno %d", errno);
+        XF_LOGI(TAG, "Socket bound, port %d", listen_addr4.sin_port);
+
+        listen_addr = (struct sockaddr *)&listen_addr4;
+    }
+
+    /* UDP 接收一直轮询，避免长时间阻塞影响 s_ctx.finish 的检测，任务无法及时退出  */
+    timeout.tv_sec  = 0;
+    timeout.tv_usec = 1000;
+    setsockopt(listen_socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+    socket_recv(listen_socket, listen_addr, IPERF_TRANS_TYPE_UDP);
+l_exit:
+    if (listen_socket != -1) {
+        shutdown(listen_socket, SHUT_RDWR);
+        closesocket(listen_socket);
+    }
+    XF_LOGI(TAG, "Udp socket server is closed.");
+    s_ctx.finish = true;
+    return ret;
+}
+
+static xf_err_t iperf_run_udp_client(void)
+{
+    int client_socket = -1;
+    int opt = 1;
+    xf_err_t ret = XF_OK;
+    struct sockaddr *dest_addr = NULL;
+    struct sockaddr_in6 dest_addr6 = { 0 };
+    struct sockaddr_in dest_addr4 = { 0 };
+
+    XF_ASSERT_RET_GOTO((s_ctx.cfg.type == IPERF_IP_TYPE_IPV6 || s_ctx.cfg.type == IPERF_IP_TYPE_IPV4),
+                       XF_FAIL, l_exit, TAG, "Ivalid AF types");
+
+    if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV6) {
+        inet6_aton(s_ctx.cfg.destination_ip6, &dest_addr6.sin6_addr);
+        dest_addr6.sin6_family = AF_INET6;
+        dest_addr6.sin6_port = htons(s_ctx.cfg.dport);
+
+        client_socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_IPV6);
+        XF_ASSERT_RET_GOTO((client_socket >= 0), XF_FAIL, l_exit, TAG, "Unable to create socket: errno %d", errno);
+        XF_LOGI(TAG, "Socket created, sending to %s:%d", s_ctx.cfg.destination_ip6, s_ctx.cfg.dport);
+
+        setsockopt(client_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        dest_addr = (struct sockaddr *)&dest_addr6;
+    } else if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV4) {
+        dest_addr4.sin_family = AF_INET;
+        dest_addr4.sin_port = htons(s_ctx.cfg.dport);
+        dest_addr4.sin_addr.s_addr = s_ctx.cfg.destination_ip4;
+
+        client_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+        XF_ASSERT_RET_GOTO((client_socket >= 0), XF_FAIL, l_exit, TAG, "Unable to create socket: errno %d", errno);
+        XF_LOGI(TAG, "Socket created, sending to " XF_IPSTR ":%d",
+                XF_IP2STR((xf_ip4_addr_t *)&s_ctx.cfg.destination_ip4), s_ctx.cfg.dport);
+
+        setsockopt(client_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        dest_addr = (struct sockaddr *)&dest_addr4;
+    }
+
+    socket_send(client_socket, dest_addr, IPERF_TRANS_TYPE_UDP, s_ctx.cfg.bw_lim);
+l_exit:
+    if (client_socket != -1) {
+        shutdown(client_socket, SHUT_RDWR);
+        closesocket(client_socket);
+    }
+    s_ctx.finish = true;
+    XF_LOGI(TAG, "UDP Socket client is closed");
+    return ret;
+}
+
+static void iperf_task_traffic(void *arg)
+{
+    if (iperf_is_udp_client()) {
+        iperf_run_udp_client();
+    } else if (iperf_is_udp_server()) {
+        iperf_run_udp_server();
+    } else if (iperf_is_tcp_client()) {
+        iperf_run_tcp_client();
+    } else {
+        iperf_run_tcp_server();
+    }
+
+    if (s_ctx.buffer) {
+        xf_free(s_ctx.buffer);
+        s_ctx.buffer = NULL;
+    }
+    s_ctx.traffic_is_running = false;
+    XF_LOGI(TAG, "iperf done");
+    xf_osal_thread_delete(NULL);
+}
+
+static uint32_t iperf_get_buffer_len(void)
+{
+    if (iperf_is_udp_client()) {
+#ifdef CONFIG_LWIP_IPV6
+        if (s_ctx.cfg.len_send_buf) {
+            return s_ctx.cfg.len_send_buf;
+        } else if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV6) {
+            return IPERF_DEFAULT_IPV6_UDP_TX_LEN;
+        } else {
+            return IPERF_DEFAULT_IPV4_UDP_TX_LEN;
+        }
+#else
+        return (s_ctx.cfg.len_send_buf == 0
+                ? IPERF_DEFAULT_IPV4_UDP_TX_LEN
+                : s_ctx.cfg.len_send_buf);
+#endif
+    } else if (iperf_is_udp_server()) {
+        return IPERF_DEFAULT_UDP_RX_LEN;
+    } else if (iperf_is_tcp_client()) {
+        return (s_ctx.cfg.len_send_buf == 0
+                ? IPERF_DEFAULT_TCP_TX_LEN
+                : s_ctx.cfg.len_send_buf);
+    } else {
+        return IPERF_DEFAULT_TCP_RX_LEN;
+    }
+    return 0;
+}
+
+static uint32_t iperf_get_float_int(float in)
+{
+    return (uint32_t)(((uint64_t)(in * IPERF_HUNDRED)) / IPERF_HUNDRED);
+}
+
+static uint32_t iperf_get_float_dec(float in)
+{
+    return (uint32_t)(((uint64_t)(in * IPERF_HUNDRED)) % IPERF_HUNDRED);
+}

--- a/components/xf_net_apps/xf_iperf/xf_iperf.h
+++ b/components/xf_net_apps/xf_iperf/xf_iperf.h
@@ -1,0 +1,263 @@
+/**
+ * @file xf_iperf.h
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-09-26
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* Iperf Example - iperf declaration
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+#ifndef __XF_IPERF_H__
+#define __XF_IPERF_H__
+
+/* ==================== [Includes] ========================================== */
+
+#include "xf_utils.h"
+#include "xf_osal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ==================== [Defines] =========================================== */
+
+#define IPERF_IP_TYPE_IPV4              0
+#define IPERF_IP_TYPE_IPV6              1
+#define IPERF_TRANS_TYPE_TCP            0
+#define IPERF_TRANS_TYPE_UDP            1
+
+#define IPERF_FLAG_SET(cfg, flag)       ((cfg) |= (flag))
+#define IPERF_FLAG_CLR(cfg, flag)       ((cfg) &= (~(flag)))
+
+#define IPERF_FLAG_CLIENT               (1)
+#define IPERF_FLAG_SERVER               (1 << 1)
+#define IPERF_FLAG_TCP                  (1 << 2)
+#define IPERF_FLAG_UDP                  (1 << 3)
+
+#define IPERF_DEFAULT_PORT              5001
+#define IPERF_DEFAULT_INTERVAL          1
+#define IPERF_DEFAULT_TIME              30
+#define IPERF_DEFAULT_NO_BW_LIMIT       -1
+
+#define IPERF_TRAFFIC_TASK_NAME         "iperf_traffic"
+#define IPERF_TRAFFIC_TASK_PRIORITY     XF_OSAL_PRIORITY_NORMOL
+#define IPERF_TRAFFIC_TASK_STACK        4096
+#define IPERF_REPORT_TASK_NAME          "iperf_report"
+#define IPERF_REPORT_TASK_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define IPERF_REPORT_TASK_STACK         4096
+
+#define IPERF_DEFAULT_IPV4_UDP_TX_LEN   (1470)
+#define IPERF_DEFAULT_IPV6_UDP_TX_LEN   (1450)
+#define IPERF_DEFAULT_UDP_RX_LEN        (16 << 10)
+#define IPERF_DEFAULT_TCP_TX_LEN        (16 << 10)
+#define IPERF_DEFAULT_TCP_RX_LEN        (16 << 10)
+
+#define IPERF_MAX_DELAY                 64
+
+#define IPERF_SOCKET_RX_TIMEOUT_MS      3000
+
+/* ==================== [Typedefs] ========================================== */
+
+/**
+ * @brief iperf 上下文的预声明。
+ */
+struct _xf_iperf_ctx_t;
+
+/**
+ * @brief iperf 句柄。
+ */
+typedef struct _xf_iperf_ctx_t *xf_iperf_t;
+
+/**
+ * @brief iperf 事件声明。
+ */
+typedef enum _xf_iperf_event_code_t {
+    XF_IPERF_EVENT_START = 0x00,        /*!< iperf 开始。 */
+    XF_IPERF_EVENT_REPORT,              /*!< iperf 报告带宽。
+                                         *   事件数据见
+                                         *   @ref xf_iperf_t->curr_time,
+                                         *   @ref xf_iperf_t->actual_len,
+                                         *   和 @ref xf_iperf_t->actual_bandwidth.
+                                         */
+    XF_IPERF_EVENT_END,                 /*!< iperf 完成。
+                                         *   事件数据见 @ref xf_iperf_t->average_bandwidth.
+                                         *   不要在回调内重启 iperf.
+                                         */
+
+    XF_IPERF_EVENT_MAX,                 /*!< iperf 事件 ID 最大值，无效 ID。 */
+} xf_iperf_event_code_t;
+
+/**
+ * @brief iperf 事件 id。见 @ref xf_iperf_event_code_t.
+ */
+typedef int32_t xf_iperf_event_id_t;
+
+/**
+ * @brief iperf 回调函数原型。
+ *
+ * 不要在回调内重启 iperf.
+ *
+ * @param event_id 事件 id. 根据事件类型, 见 @ref xf_iperf_event_code_t.
+ * @param hdl 事件数据. 见 @ref xf_iperf_ctx_t.
+ * @param user_args 用户数据. `xf_iperf_new_session()` 时传入.
+ */
+typedef void (*xf_iperf_cb_t)(
+    xf_iperf_event_id_t event_id, xf_iperf_t hdl, void *user_args);
+
+/**
+ * @brief iperf 配置类型。
+ */
+typedef struct _xf_iperf_cfg_t {
+    uint32_t flag;                  /*!< 设定客户端或服务端/协议的标志，
+                                     *   见 @ref IPERF_FLAG_CLIENT, @ref IPERF_FLAG_TCP.
+                                     */
+    union {
+        uint32_t destination_ip4;   /*!< 目标 ipv4 地址。 */
+        char    *destination_ip6;   /*!< 目标 ipv6 地址。 */
+    };
+    union {
+        uint32_t source_ip4;        /*!< 源 ipv4 地址。 */
+        char    *source_ip6;        /*!< 源 ipv6 地址。 */
+    };
+    uint8_t type;                   /*!< 源和目标的地址类型。 */
+    uint16_t dport;                 /*!< 目标端口。 */
+    uint16_t sport;                 /*!< 源端口。 */
+    uint32_t interval;              /*!< 报告间隔，单位 s. */
+    uint32_t time;                  /*!< iperf 运行总时间，单位 s. */
+    uint16_t len_send_buf;          /*!< iperf 每包缓冲区的长度，填入 0 时使用
+                                     *   @ref IPERF_DEFAULT_IPV4_UDP_TX_LEN
+                                     *   或 @ref IPERF_DEFAULT_IPV6_UDP_TX_LEN.
+                                     */
+    int32_t bw_lim;                 /*!< 带宽限制，单位 Mbits/sec. */
+
+    uint32_t traffic_task_stack_size;   /*!< 内部 traffic 任务的堆栈大小。 */
+    uint32_t traffic_task_prio;         /*!< 内部 traffic 任务的优先级。 */
+
+    bool report_enabled;                /*!< 是否使能内部 report 任务报告带宽。 */
+    uint32_t report_task_stack_size;    /*!< 内部 report 任务的堆栈大小。 */
+    uint32_t report_task_prio;          /*!< 内部 report 任务的优先级。 */
+} xf_iperf_cfg_t;
+
+/**
+ * @brief 默认 iperf 配置
+ */
+#define XF_IPERF_DEFAULT_CONFIG() (xf_iperf_cfg_t) { \
+        .flag = 0, \
+        .destination_ip4 = 0, \
+        .source_ip4 = 0, \
+        .type = IPERF_IP_TYPE_IPV4, \
+        .dport = IPERF_DEFAULT_PORT, \
+        .sport = IPERF_DEFAULT_PORT, \
+        .interval = IPERF_DEFAULT_INTERVAL, \
+        .time = IPERF_DEFAULT_TIME, \
+        .len_send_buf = 0, \
+        .bw_lim = IPERF_DEFAULT_NO_BW_LIMIT, \
+        .traffic_task_stack_size = IPERF_TRAFFIC_TASK_STACK, \
+        .traffic_task_prio = IPERF_TRAFFIC_TASK_PRIORITY, \
+        .report_enabled = true, \
+        .report_task_stack_size = IPERF_REPORT_TASK_STACK, \
+        .report_task_prio = IPERF_REPORT_TASK_PRIORITY, \
+    }
+
+
+/**
+ * @brief iperf 上下文.
+ * @attention 只有 `public:` 部分是在回调中可读的，
+ *            用户 **禁止** 修改其中任何内容。
+ */
+typedef struct _xf_iperf_ctx_t {
+    /* public: */
+    /* 只读数据 */
+    xf_iperf_cfg_t cfg;                 /*!< xf_iperf_start() 传入的配置备份。 */
+    uint32_t curr_time;                 /*!< 当前报告时刻，单位 s.
+                                         *   注意，每次报告时间差见 @ref xf_iperf_t->cfg.interval.
+                                         */
+    uint32_t actual_len;                /*!< 本次报告周期内，
+                                         *   (xf_iperf_t->curr_time ~ xf_iperf_t->curr_time + xf_iperf_t->cfg.interval)
+                                         *   实际发送或者接收到的数据长度(单位字节)。
+                                         */
+    float actual_bandwidth;             /*!< 本次报告周期内的实际带宽(单位 Mbits/sec)。 */
+    float average_bandwidth;            /*!< 总的平均带宽(单位 Mbits/sec)。 */
+
+    /* privte: */
+    bool finish;                        /*!< 传输完毕标志或强制结束标志。 */
+    uint32_t sockfd;                    /*!< socket 文件描述符。 */
+    uint8_t *buffer;                    /*!< 内部测速缓冲区 */
+    uint32_t buffer_len;                /*!< 每 tcp/udp 包长度。 */
+    uint32_t actual_len_internal;       /*!< 本次报告周期内，
+                                         *   实际发送或者接收到的数据长度(单位字节)。
+                                         *   内部使用。
+                                         */
+
+    xf_iperf_cb_t cb_func;              /*!< 传入的回调函数 。*/
+    void *user_args;                    /*!< 传入的回调函数的用户参数。 */
+
+    xf_osal_thread_t traffic_task_hdl;  /*!< 内部 traffic 任务句柄。 */
+    bool traffic_is_running;            /*!< 内部 traffic 任务是否正在运行。 */
+
+    xf_osal_thread_t report_task_hdl;   /*!< 内部 report 任务句柄。 */
+    bool report_is_running;             /*!< 内部 report 任务否正在运行。 */
+} xf_iperf_ctx_t;
+
+/* ==================== [Global Prototypes] ================================= */
+
+/**
+ * @brief 启动 iperf.
+ *
+ * @note iperf 通常用于测试网络极限性能，因此不打算支持多实例。
+ *
+ * @param p_cfg iperf 配置。
+ * @return xf_err_t
+ *      - XF_ERR_INVALID_ARG 无效参数（例如配置为空等）
+ *      - XF_ERR_NO_MEM 内存不足
+ *      - XF_FAIL 其他内部错误（例如套接字错误）
+ *      - XF_OK 成功
+ */
+xf_err_t xf_iperf_start(
+    const xf_iperf_cfg_t *p_cfg, xf_iperf_cb_t cb_func, void *user_args);
+
+/**
+ * @brief 获取 iperf 句柄。
+ *
+ * @return xf_iperf_t
+ *      - NULL 失败
+ *      - (OTHER) 成功
+ */
+xf_iperf_t xf_iperf_get_handle(void);
+
+/**
+ * @brief 检查 iperf 是否正在运行。
+ *
+ * @return
+ *      - true 是
+ *      - false 否
+ */
+bool xf_iperf_is_running(void);
+
+/**
+ * @brief 停止 iperf.
+ *
+ * @return
+ *      - XF_OK 成功
+ *      - XF_FAIL 其他内部错误（例如套接字错误）
+ */
+xf_err_t xf_iperf_stop(void);
+
+/* ==================== [Macros] ============================================ */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __XF_IPERF_H__ */

--- a/components/xf_net_apps/xf_net_apps.h
+++ b/components/xf_net_apps/xf_net_apps.h
@@ -1,0 +1,43 @@
+/**
+ * @file xf_nal_config.h
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 0.1
+ * @date 2024-10-11
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+#ifndef __XF_NET_APPS_H__
+#define __XF_NET_APPS_H__
+
+/* ==================== [Includes] ========================================== */
+
+#include "xf_net_apps_config_internal.h"
+
+#if XF_NET_APPS_IPERF_IS_ENABLE
+#include "xf_iperf.h"
+#endif
+
+#if XF_NET_APPS_PING_IS_ENABLE
+#include "xf_ping.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ==================== [Defines] =========================================== */
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Global Prototypes] ================================= */
+
+/* ==================== [Macros] ============================================ */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif // __XF_NET_APPS_H__

--- a/components/xf_net_apps/xf_net_apps_config.h
+++ b/components/xf_net_apps/xf_net_apps_config.h
@@ -1,0 +1,38 @@
+/**
+ * @file xf_net_apps_config.h
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief 使用 xfusion 菜单配置 xf_net_apps 内部配置。
+ * @version 0.1
+ * @date 2024-10-11
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+#ifndef __XF_NET_APPS_CONFIG_H__
+#define __XF_NET_APPS_CONFIG_H__
+
+/* ==================== [Includes] ========================================== */
+
+#include "xfconfig.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ==================== [Defines] =========================================== */
+
+#define XF_NET_APPS_IPERF_ENABLE        CONFIG_XF_NET_APPS_IPERF_ENABLE
+#define XF_NET_APPS_PING_ENABLE         CONFIG_XF_NET_APPS_PING_ENABLE
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Global Prototypes] ================================= */
+
+/* ==================== [Macros] ============================================ */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif // __XF_NET_APPS_CONFIG_H__

--- a/components/xf_net_apps/xf_net_apps_config_internal.h
+++ b/components/xf_net_apps/xf_net_apps_config_internal.h
@@ -1,0 +1,48 @@
+/**
+ * @file xf_net_apps_config_internal_h.h
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief xf_netif 模块内部配置总头文件。
+ *        确保 xf_netif_config.h 的所有定义都有默认值。
+ * @version 1.0
+ * @date 2024-09-24
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+#ifndef __XF_NET_APPS_CONFIG_INTERNAL_H_H__
+#define __XF_NET_APPS_CONFIG_INTERNAL_H_H__
+
+/* ==================== [Includes] ========================================== */
+
+#include "xf_net_apps_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ==================== [Defines] =========================================== */
+
+#if !defined(XF_NET_APPS_IPERF_ENABLE) || (XF_NET_APPS_IPERF_ENABLE)
+#   define XF_NET_APPS_IPERF_IS_ENABLE      (1)
+#else
+#   define XF_NET_APPS_IPERF_IS_ENABLE      (0)
+#endif
+
+#if !defined(XF_NET_APPS_PING_ENABLE) || (XF_NET_APPS_PING_ENABLE)
+#   define XF_NET_APPS_PING_IS_ENABLE       (1)
+#else
+#   define XF_NET_APPS_PING_IS_ENABLE       (0)
+#endif
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Global Prototypes] ================================= */
+
+/* ==================== [Macros] ============================================ */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif // __XF_NET_APPS_CONFIG_INTERNAL_H_H__

--- a/components/xf_net_apps/xf_ping/xf_ping.c
+++ b/components/xf_net_apps/xf_ping/xf_ping.c
@@ -1,0 +1,431 @@
+/**
+ * @file xf_ping.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-10-12
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "lwip/opt.h"
+#include "lwip/init.h"
+#include "lwip/mem.h"
+#include "lwip/icmp.h"
+#include "lwip/netif.h"
+#include "lwip/sys.h"
+#include "lwip/timeouts.h"
+#include "lwip/inet.h"
+#include "lwip/inet_chksum.h"
+#include "lwip/ip.h"
+#include "lwip/netdb.h"
+#include "lwip/sockets.h"
+
+#include "xf_sys.h"
+#include "xf_ping.h"
+
+/* ==================== [Defines] =========================================== */
+
+#define PING_TIME_DIFF_MS(_end, _start) \
+    ((uint32_t)((_end - _start) / 1000))
+
+#define PING_CHECK_START_TIMEOUT_MS (100)
+
+#define PING_FLAGS_INIT         (1 << 0)
+#define PING_FLAGS_RUN          (1 << 1)
+
+#define THREAD_NOTIFY_BIT       0x01
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static xf_err_t xf_ping_send(xf_ping_ctx_t *ctx);
+static int xf_ping_receive(xf_ping_ctx_t *ctx);
+static void xf_ping_thread(void *args);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "xf_ping";
+
+/* ==================== [Macros] ============================================ */
+
+#define XF_GOTO_ON_FALSE(a, err_code, goto_tag, log_tag, format, ...) \
+    do { \
+        if (unlikely(!(a))) { \
+            XF_LOGE(log_tag, format, ##__VA_ARGS__); \
+            ret = err_code; \
+            goto goto_tag; \
+        } \
+    } while (0)
+
+/* ==================== [Global Functions] ================================== */
+
+xf_err_t xf_ping_new_session(
+    const xf_ping_cfg_t *p_cfg, xf_ping_cb_t cb_func, void *user_args,
+    xf_ping_t *hdl_out)
+{
+    xf_err_t ret = XF_FAIL;
+    xf_ping_ctx_t *ctx = NULL;
+
+    XF_GOTO_ON_FALSE(p_cfg, XF_ERR_INVALID_ARG, l_err,
+                     TAG, "p_cfg-%s", xf_err_to_name(XF_ERR_INVALID_ARG));
+    XF_GOTO_ON_FALSE(hdl_out, XF_ERR_INVALID_ARG, l_err,
+                     TAG, "hdl_out-%s", xf_err_to_name(XF_ERR_INVALID_ARG));
+
+    ctx = xf_malloc(sizeof(xf_ping_ctx_t));
+    XF_GOTO_ON_FALSE(ctx, XF_ERR_NO_MEM, l_err,
+                     TAG, "ping_ctx-%s", xf_err_to_name(XF_ERR_NO_MEM));
+    xf_memset(ctx, 0x00, sizeof(xf_ping_ctx_t));
+
+    /* 防止 ping 任务退出 */
+    BITS_SET1(ctx->flags, PING_FLAGS_INIT);
+
+    ctx->task_exit_flag = false;
+    xf_osal_thread_attr_t thread_attr = {
+        .name       = XF_PING_THREAD_NAME,
+        .priority   = p_cfg->task_prio,
+        .stack_size = p_cfg->task_stack_size,
+    };
+    ctx->task_hdl = xf_osal_thread_create(xf_ping_thread, ctx, &thread_attr);
+    XF_GOTO_ON_FALSE(ctx->task_hdl != NULL, XF_ERR_NO_MEM, l_err,
+                     TAG, "ping_task-%s", xf_err_to_name(XF_ERR_NO_MEM));
+
+    if (cb_func) {
+        ctx->cb_func    = cb_func;
+        ctx->user_args  = user_args;
+    }
+    ctx->recv_addr          = p_cfg->target_addr;
+    ctx->target_addr_type   = p_cfg->target_addr.type;
+    ctx->count              = p_cfg->count;
+    ctx->interval_ms        = p_cfg->interval_ms;
+    ctx->icmp_pkt_size      = sizeof(struct icmp_echo_hdr) + p_cfg->data_size;
+    ctx->packet_hdr         = xf_malloc(ctx->icmp_pkt_size);
+    XF_GOTO_ON_FALSE(ctx->packet_hdr, XF_ERR_NO_MEM, l_err,
+                     TAG, "icmp_pkt-%s", xf_err_to_name(XF_ERR_NO_MEM));
+    xf_memset(ctx->packet_hdr, 0x00, ctx->icmp_pkt_size);
+
+    ctx->packet_hdr->code = 0;
+    ctx->packet_hdr->id = ((uint32_t)ctx->task_hdl) & 0xFFFF; /*!< 任务句柄唯一，视为 ping ID  */
+
+    char *d = (char *)(ctx->packet_hdr) + sizeof(struct icmp_echo_hdr);
+    for (uint32_t i = 0; i < p_cfg->data_size; i++) {
+        d[i] = 'A' + i;
+    }
+
+    /* 创建 socket */
+    if (IP_IS_V4(&p_cfg->target_addr)
+#if CONFIG_LWIP_IPV6
+            || ip6_addr_isipv4mappedipv6(ip_2_ip6(&p_cfg->target_addr))
+#endif
+       ) {
+        ctx->sock = socket(AF_INET, SOCK_RAW, IP_PROTO_ICMP);
+    }
+#if CONFIG_LWIP_IPV6
+    else {
+        ctx->sock = socket(AF_INET6, SOCK_RAW, IP6_NEXTH_ICMP6);
+    }
+#endif
+    XF_GOTO_ON_FALSE(ctx->sock >= 0, XF_FAIL, l_err,
+                     TAG, "create socket failed: %d", ctx->sock);
+
+    if (p_cfg->interface) {
+        struct ifreq iface;
+        if (netif_index_to_name(p_cfg->interface, iface.ifr_name) == NULL) {
+            XF_LOGE(TAG, "fail to find interface name with netif index %d",
+                    p_cfg->interface);
+            goto l_err;
+        }
+        if (setsockopt(ctx->sock, SOL_SOCKET, SO_BINDTODEVICE, &iface, sizeof(iface)) != 0) {
+            XF_LOGE(TAG, "fail to setsockopt SO_BINDTODEVICE");
+            goto l_err;
+        }
+    }
+
+    struct timeval timeout;
+    timeout.tv_sec  = p_cfg->timeout_ms / 1000;
+    timeout.tv_usec = (p_cfg->timeout_ms % 1000) * 1000;
+    setsockopt(ctx->sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    setsockopt(ctx->sock, IPPROTO_IP, IP_TOS, &p_cfg->tos, sizeof(p_cfg->tos));
+    setsockopt(ctx->sock, IPPROTO_IP, IP_TTL, &p_cfg->ttl, sizeof(p_cfg->ttl));
+
+    if (IP_IS_V4(&p_cfg->target_addr)) {
+        struct sockaddr_in *to4 = (struct sockaddr_in *)&ctx->target_addr;
+        to4->sin_family = AF_INET;
+        inet_addr_from_ip4addr(&to4->sin_addr, ip_2_ip4(&p_cfg->target_addr));
+        ctx->packet_hdr->type = ICMP_ECHO;
+    }
+#if CONFIG_LWIP_IPV6
+    if (IP_IS_V6(&p_cfg->target_addr)) {
+        struct sockaddr_in6 *to6 = (struct sockaddr_in6 *)&ctx->target_addr;
+        to6->sin6_family = AF_INET6;
+        inet6_addr_from_ip6addr(&to6->sin6_addr, ip_2_ip6(&p_cfg->target_addr));
+        ctx->packet_hdr->type = ICMP6_TYPE_EREQ;
+    }
+#endif
+
+    *hdl_out = (xf_ping_t)ctx;
+
+    return XF_OK;
+
+l_err:
+    if (ctx) {
+        if (ctx->sock > 0) {
+            closesocket(ctx->sock);
+        }
+        if (ctx->packet_hdr) {
+            xf_free(ctx->packet_hdr);
+        }
+        if (ctx->task_hdl) {
+            xf_osal_thread_delete(ctx->task_hdl);
+        }
+        xf_free(ctx);
+    }
+    return ret;
+}
+
+xf_err_t xf_ping_delete_session(xf_ping_t hdl)
+{
+    xf_err_t ret = XF_OK;
+    xf_ping_ctx_t *ctx = (xf_ping_ctx_t *)hdl;
+    XF_GOTO_ON_FALSE(ctx, XF_ERR_INVALID_ARG, l_err,
+                     TAG, "hdl-%s", xf_err_to_name(XF_ERR_INVALID_ARG));
+
+    BITS_SET0(ctx->flags, PING_FLAGS_INIT);
+
+    size_t wait_cnt = 0;
+#define WAIT_CNT_MAX    1000
+    while (ctx->task_exit_flag != true) {
+        xf_osal_delay_ms(10);
+        wait_cnt++;
+        if (wait_cnt >= WAIT_CNT_MAX) {
+            xf_osal_thread_delete(ctx->task_hdl);
+            xf_osal_delay_ms(50);
+            break;
+        }
+    }
+
+    xf_free(ctx);
+
+    return XF_OK;
+l_err:
+    return ret;
+}
+
+xf_err_t xf_ping_start(xf_ping_t hdl)
+{
+    xf_err_t ret = XF_OK;
+    xf_ping_ctx_t *ctx = (xf_ping_ctx_t *)hdl;
+    XF_GOTO_ON_FALSE(ctx, XF_ERR_INVALID_ARG, l_err,
+                     TAG, "hdl-%s", xf_err_to_name(XF_ERR_INVALID_ARG));
+
+    BITS_SET1(ctx->flags, PING_FLAGS_RUN);
+    xf_osal_thread_notify_set(ctx->task_hdl, THREAD_NOTIFY_BIT);
+
+    return XF_OK;
+l_err:
+    return ret;
+}
+
+bool xf_ping_is_running(xf_ping_t hdl)
+{
+    bool ret = false;
+    xf_ping_ctx_t *ctx = (xf_ping_ctx_t *)hdl;
+    XF_GOTO_ON_FALSE(ctx, false, l_err,
+                     TAG, "hdl-%s", xf_err_to_name(XF_ERR_INVALID_ARG));
+    return ctx->ping_running_flag;
+l_err:
+    return ret;
+}
+
+xf_err_t xf_ping_stop(xf_ping_t hdl)
+{
+    xf_err_t ret = XF_OK;
+    xf_ping_ctx_t *ctx = (xf_ping_ctx_t *)hdl;
+    XF_GOTO_ON_FALSE(ctx, XF_ERR_INVALID_ARG, l_err,
+                     TAG, "hdl-%s", xf_err_to_name(XF_ERR_INVALID_ARG));
+
+    BITS_SET0(ctx->flags, PING_FLAGS_RUN);
+
+    return XF_OK;
+l_err:
+    return ret;
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static xf_err_t xf_ping_send(xf_ping_ctx_t *ctx)
+{
+    xf_err_t ret = XF_OK;
+
+    ctx->packet_hdr->seqno++;
+    /* seqno 已更改，重新计算校验和 */
+    ctx->packet_hdr->chksum = 0;
+    if (ctx->packet_hdr->type == ICMP_ECHO) {
+        ctx->packet_hdr->chksum = inet_chksum(ctx->packet_hdr, ctx->icmp_pkt_size);
+    }
+
+    socklen_t socklen = (ctx->target_addr_type == IPADDR_TYPE_V4)
+                        ? sizeof(struct sockaddr_in)
+                        : sizeof(struct sockaddr_in6);
+    ssize_t sent = sendto(ctx->sock, ctx->packet_hdr, ctx->icmp_pkt_size, 0,
+                          (struct sockaddr *)&ctx->target_addr, socklen);
+
+    if (sent != (ssize_t)ctx->icmp_pkt_size) {
+        int opt_val;
+        socklen_t opt_len = sizeof(opt_val);
+        getsockopt(ctx->sock, SOL_SOCKET, SO_ERROR, &opt_val, &opt_len);
+        XF_LOGE(TAG, "send error=%d", opt_val);
+        ret = XF_FAIL;
+    } else {
+        ctx->transmitted++;
+    }
+    return ret;
+}
+
+static int xf_ping_receive(xf_ping_ctx_t *ctx)
+{
+    char buf[64]; /*!< sock buffer, 64 字节足以容纳 IP 头和 ICMP 头 */
+    int len = 0;
+    struct sockaddr_storage from;
+
+    int fromlen = (ctx->target_addr_type == IPADDR_TYPE_V4)
+                  ? sizeof(struct sockaddr_in)
+                  : sizeof(struct sockaddr_in6);
+    uint16_t data_head = 0;
+
+    while ((len = recvfrom(ctx->sock, buf, sizeof(buf), 0,
+                           (struct sockaddr *)&from, (socklen_t *)&fromlen)) > 0) {
+        if (from.ss_family == AF_INET) {
+            // IPv4
+            struct sockaddr_in *from4 = (struct sockaddr_in *)&from;
+            inet_addr_to_ip4addr(ip_2_ip4(&ctx->recv_addr), &from4->sin_addr);
+            IP_SET_TYPE_VAL(ctx->recv_addr, IPADDR_TYPE_V4);
+            data_head = (uint16_t)(sizeof(struct ip_hdr) + sizeof(struct icmp_echo_hdr));
+        }
+#if CONFIG_LWIP_IPV6
+        else {
+            // IPv6
+            struct sockaddr_in6 *from6 = (struct sockaddr_in6 *)&from;
+            inet6_addr_to_ip6addr(ip_2_ip6(&ctx->recv_addr), &from6->sin6_addr);
+            IP_SET_TYPE_VAL(ctx->recv_addr, IPADDR_TYPE_V6);
+            data_head = (uint16_t)(sizeof(struct ip6_hdr) + sizeof(struct icmp6_echo_hdr));
+        }
+#endif
+        if (len >= data_head) {
+            if (IP_IS_V4_VAL(ctx->recv_addr)) {
+                struct ip_hdr *iphdr = (struct ip_hdr *)buf;
+                struct icmp_echo_hdr *iecho = (struct icmp_echo_hdr *)(buf + (IPH_HL(iphdr) * 4));
+                if ((iecho->id == ctx->packet_hdr->id) && (iecho->seqno == ctx->packet_hdr->seqno)) {
+                    ctx->received++;
+                    ctx->ttl = iphdr->_ttl;
+                    ctx->tos = iphdr->_tos;
+                    ctx->recv_len = lwip_ntohs(IPH_LEN(iphdr)) - data_head;  /*!< ICMP 的数据部分 */
+                    return len;
+                }
+            }
+#if CONFIG_LWIP_IPV6
+            else if (IP_IS_V6_VAL(ctx->recv_addr)) {
+                struct ip6_hdr *iphdr = (struct ip6_hdr *)buf;
+                struct icmp6_echo_hdr *iecho6 = (struct icmp6_echo_hdr *)(buf + sizeof(struct ip6_hdr)); /*!< IPv6 头长度为 40 */
+                if ((iecho6->id == ctx->packet_hdr->id) && (iecho6->seqno == ctx->packet_hdr->seqno)) {
+                    ctx->received++;
+                    ctx->recv_len = IP6H_PLEN(iphdr) - sizeof(struct icmp6_echo_hdr);  /*!< ICMP 的数据部分 */
+                    return len;
+                }
+            }
+#endif
+        }
+        fromlen = (ctx->target_addr_type == IPADDR_TYPE_V4)
+                  ? sizeof(struct sockaddr_in)
+                  : sizeof(struct sockaddr_in6);
+    }
+    /* 如果超时，len 将为 -1 */
+    return len;
+}
+
+static void xf_ping_thread(void *args)
+{
+    xf_ping_ctx_t *ctx = (xf_ping_ctx_t *)(args);
+    int recv_ret;
+    xf_err_t xf_ret = XF_OK;
+    uint32_t wait_ticks = xf_osal_kernel_ms_to_ticks(PING_CHECK_START_TIMEOUT_MS);
+    uint32_t interval_ticks;  /*!< 在循环内更新，此处赋值有可能无法获得实际值 */
+    uint32_t last_wake;
+    xf_us_t start_time, end_time;
+
+    for (;;) {
+        if (!(ctx->flags & PING_FLAGS_INIT)) {
+            break;
+        }
+        /* 此处 PING_FLAGS_RUN 避免长时间等待通知 */
+        if (!(ctx->flags & PING_FLAGS_RUN)) {
+            xf_osal_delay_ms(50);
+            continue;
+        }
+        xf_ret = xf_osal_thread_notify_wait(THREAD_NOTIFY_BIT, XF_OSAL_WAIT_ANY, wait_ticks);
+        if (xf_ret != XF_OK) {
+            continue;
+        }
+        UNUSED(xf_osal_thread_notify_get());
+        xf_osal_thread_notify_clear(THREAD_NOTIFY_BIT);
+
+        ctx->packet_hdr->seqno  = 0;
+        ctx->transmitted        = 0;
+        ctx->received           = 0;
+        ctx->total_time_ms      = 0;
+
+        /* 此处 PING_FLAGS_RUN 用于在运行时暂停 */
+        while ((ctx->flags & PING_FLAGS_RUN)
+                && ((ctx->count == 0xFFFFFFFF) || (ctx->packet_hdr->seqno < ctx->count))) {
+            last_wake = xf_osal_kernel_get_tick_count();
+
+            /*
+                ctx->flags 告诉 xf_ping_thread ping 能否运行；
+                ctx->ping_running_flag 指示 ping 是否正在运行。
+             */
+            ctx->ping_running_flag = true;
+
+            xf_ping_send(ctx);
+
+            start_time  = xf_sys_time_get_us();
+            recv_ret    = xf_ping_receive(ctx);
+            end_time    = xf_sys_time_get_us();
+
+            ctx->elapsed_time_ms    = PING_TIME_DIFF_MS(end_time, start_time);
+            ctx->total_time_ms      += ctx->elapsed_time_ms;
+
+            if (ctx->cb_func) {
+                xf_ping_event_id_t event_id = (recv_ret >= 0) ? (XF_PING_EVENT_SUCC) : (XF_PING_EVENT_TIMEOUT);
+                ctx->cb_func(event_id, (void *)ctx, ctx->user_args);
+            }
+
+            interval_ticks = xf_osal_kernel_ms_to_ticks(ctx->interval_ms);
+            if (interval_ticks) {
+                xf_osal_delay_until(last_wake + interval_ticks);
+            }
+        } /* while */
+
+        BITS_SET0(ctx->flags, PING_FLAGS_RUN);
+        ctx->ping_running_flag = false;
+
+        if (ctx->cb_func) {
+            ctx->cb_func(XF_PING_EVENT_END, (void *)ctx, ctx->user_args);
+        }
+    }
+    if (ctx->packet_hdr) {
+        xf_free(ctx->packet_hdr);
+    }
+    if (ctx->sock >= 0) {
+        closesocket(ctx->sock);
+    }
+    ctx->task_exit_flag = true;
+    /* ctx 在 xf_ping_delete_session() 内释放 */
+    xf_osal_thread_delete(NULL);
+}

--- a/components/xf_net_apps/xf_ping/xf_ping.h
+++ b/components/xf_net_apps/xf_ping/xf_ping.h
@@ -1,0 +1,209 @@
+/**
+ * @file xf_ping.h
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-10-12
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+#ifndef __XF_PING_H__
+#define __XF_PING_H__
+
+/* ==================== [Includes] ========================================== */
+
+#include "lwip/ip_addr.h"
+#include "lwip/icmp.h"
+
+#include "xf_osal.h"
+#include "xf_utils.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ==================== [Defines] =========================================== */
+
+#define XF_PING_THREAD_NAME     "xf_ping"
+
+/* ==================== [Typedefs] ========================================== */
+
+/**
+ * @brief ping 会话上下文的预声明。
+ */
+struct _xf_ping_ctx_t;
+
+/**
+ * @brief ping 会话句柄。
+ */
+typedef struct _xf_ping_ctx_t *xf_ping_t;
+
+/**
+ * @brief ping 配置类型。
+ */
+typedef struct _xf_ping_cfg_t {
+    uint32_t count;             /*!< ping 次数，0xFFFFFFFF 为无限循环。 */
+    uint32_t interval_ms;       /*!< 每两个 ping 的间隔时间(单位 ms)。 */
+    uint32_t timeout_ms;        /*!< 每次 ping 的超时时间(单位 ms)。 */
+    uint32_t data_size;         /*!< ICMP 数据包标头旁边的数据大小。 */
+    int tos;                    /*!< 服务类型，IP 标头中指定的字段。 */
+    int ttl;                    /*!< 生存时间，IP 标头中指定的字段。 */
+    ip_addr_t target_addr;      /*!< 目标 IP 地址，IPv4 或 IPv6。 */
+    uint32_t task_stack_size;   /*!< 内部 ping 任务的堆栈大小。 */
+    uint32_t task_prio;         /*!< 内部 ping 任务的优先级。 */
+    uint32_t interface;         /*!< Netif 索引，interface=0 表示 NETIF_NO_INDEX。 */
+} xf_ping_cfg_t;
+
+/**
+ * @brief 默认 ping 配置
+ */
+#define XF_PING_DEFAULT_CONFIG() (xf_ping_cfg_t) { \
+        .count = 5, \
+        .interval_ms = 1000, \
+        .timeout_ms = 1000, \
+        .data_size = 64, \
+        .tos = 0, \
+        .ttl = IP_DEFAULT_TTL, \
+        .target_addr = *(IP_ANY_TYPE), \
+        .task_stack_size = (4 * 1024), \
+        .task_prio = XF_OSAL_PRIORITY_NORMOL, \
+        .interface = 0, \
+    }
+
+/**
+ * @brief Ping 事件声明。
+ */
+typedef enum _xf_ping_event_code_t {
+    XF_PING_EVENT_SUCC = 0x00,          /*!< 收到 ICMP 应答数据包。 */
+    XF_PING_EVENT_TIMEOUT,              /*!< ICMP 应答数据包超时。 */
+    XF_PING_EVENT_END,                  /*!< ping 会话完成。 */
+
+    XF_PING_EVENT_MAX,                  /*!< ping 事件 ID 最大值，无效 ID。 */
+} xf_ping_event_code_t;
+
+/**
+ * @brief ping 事件 id。见 @ref xf_ping_event_code_t.
+ */
+typedef int32_t xf_ping_event_id_t;
+
+/**
+ * @brief ping 回调函数原型。
+ *
+ * @param event_id 事件 id. 根据事件类型, 见 @ref xf_ping_event_code_t.
+ * @param hdl 事件数据. 需要根据事件 id 强转为对应的类型.
+ * @param user_args 用户数据. `xf_ping_new_session()` 时传入.
+ */
+typedef void (*xf_ping_cb_t)(
+    xf_ping_event_id_t event_id, xf_ping_t hdl, void *user_args);
+
+/**
+ * @brief ping 会话的上下文。
+ * @attention 只有 `public:` 部分是在回调中可读的，
+ *            用户 **禁止** 修改其中任何内容。
+ */
+typedef struct _xf_ping_ctx_t {
+    /* public: */
+    /* 只读数据 */
+    struct icmp_echo_hdr *packet_hdr;   /*!< ping 序列号见 @ref packet_hdr->seqno. */
+    ip_addr_t recv_addr;                /*!< 回复的 IP 地址。 */
+    uint32_t recv_len;                  /*!< 接收到的数据包的大小。 */
+    uint32_t elapsed_time_ms;           /*!< 请求和回复数据包之间经过的时间。 */
+    uint32_t total_time_ms;             /*!< 整个 ping 会话所用的时间。 */
+    uint32_t interval_ms;               /*!< 每两个 ping 的间隔时间(单位 ms)。 */
+    uint32_t count;                     /*!< ping 会话当前计数。 */
+    uint32_t transmitted;               /*!< 发出的请求数据包数量。 */
+    uint32_t received;                  /*!< 收到的回复数据包数量。 */
+    uint8_t ttl;                        /*!< ping 生存时间。 */
+    uint8_t tos;                        /*!< ping 服务类型。 */
+
+    /* privte: */
+    int sock;                           /*!< socket 文件描述符。 */
+    /*
+        struct sockaddr_storage 太大，在某些芯片上(ws63)无法正常收发，不使用。
+        struct sockaddr_storage target_addr;
+     */
+    union sockaddr_in_in6_u {
+        struct sockaddr_in in;
+        struct sockaddr_in6 in6;
+    } target_addr;                      /*!< 目标 sockaddr. */
+    uint8_t target_addr_type;           /*!< 目标 sockaddr 的类型。 */
+
+    uint32_t flags;                     /*!< 内部标志。 */
+    uint32_t icmp_pkt_size;             /*!< ICMP 包长。 */
+
+    xf_osal_thread_t task_hdl;          /*!< 内部任务句柄。 */
+    uint8_t task_exit_flag;             /*!< 内部任务结束标志。 */
+    uint8_t ping_running_flag;          /*!< ping 是否正在进行。 */
+
+    xf_ping_cb_t cb_func;               /*!< 传入的回调函数 。*/
+    void *user_args;                    /*!< 传入的回调函数的用户参数。 */
+} xf_ping_ctx_t;
+
+/* ==================== [Global Prototypes] ================================= */
+
+/**
+ * @brief 创建 ping 会话。
+ *
+ * @param p_cfg ping 配置。
+ * @param cb_func ping 事件回调。
+ * @param user_args ping 事件回调中的用户参数。
+ * @param[out] hdl_out ping 会话句柄。
+ * @return
+ *      - XF_ERR_INVALID_ARG 无效参数（例如配置为空等）
+ *      - XF_ERR_NO_MEM 内存不足
+ *      - XF_FAIL 其他内部错误（例如套接字错误）
+ *      - XF_OK 成功
+ */
+xf_err_t xf_ping_new_session(
+    const xf_ping_cfg_t *p_cfg, xf_ping_cb_t cb_func, void *user_args,
+    xf_ping_t *hdl_out);
+
+/**
+ * @brief 删除 ping 会话。
+ *
+ * @param hdl ping 会话句柄。
+ * @return
+ *      - XF_ERR_INVALID_ARG 无效参数
+ *      - XF_OK 成功
+ */
+xf_err_t xf_ping_delete_session(xf_ping_t hdl);
+
+/**
+ * @brief 启动 ping 会话。
+ *
+ * @param hdl ping 会话句柄
+ * @return
+ *      - XF_ERR_INVALID_ARG 无效参数
+ *      - XF_OK 成功
+ */
+xf_err_t xf_ping_start(xf_ping_t hdl);
+
+/**
+ * @brief 检查 ping 是否正在运行。
+ *
+ * @param hdl ping 会话句柄
+ * @return
+ *      - true 是
+ *      - false 否
+ */
+bool xf_ping_is_running(xf_ping_t hdl);
+
+/**
+ * @brief 停止 ping 会话。
+ *
+ * @param hdl ping 会话句柄
+ * @return
+ *      - XF_ERR_INVALID_ARG 无效参数
+ *      - XF_OK 成功
+ */
+xf_err_t xf_ping_stop(xf_ping_t hdl);
+
+/* ==================== [Macros] ============================================ */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __XF_PING_H__ */

--- a/examples/example_components/README.md
+++ b/examples/example_components/README.md
@@ -1,0 +1,64 @@
+# 关于 example_components
+
+`example_components` 是基于 xfusion api 且更偏向应用的组件。
+
+相较于 `components`，`example_components` 不对通用性做严格要求，在 xfusion 或者外部组件库没有相关功能的情况下，允许通过判断平台包含平台相关代码，或者是实验性相关代码。
+
+`example_components` 通过验证的代码在添加各平台支持后可以加入系统组件 `components`。
+
+## 使用方法
+
+如 `examples/protocols/http_request/xf_project.py` 所示：
+
+```python
+import xf_build
+from xf_build import api
+from pathlib import Path
+
+example_components_path: Path = api.XF_ROOT / "examples" / "example_components_path"
+
+example_components = []
+example_components.append((example_components_path / "ex_easy_wifi").as_posix())
+
+xf_build.project_init(user_dirs=example_components)
+xf_build.program()
+```
+
+通过以上工程脚本实现了添加名为 `ex_easy_wifi` 的组件。
+
+注意，如果添加的组件依赖于另外一个示例组件，也需要手动加入。
+
+## 备注
+
+### 允许通过判断平台包含平台相关代码的示例
+
+在 xf_sys 不存在时，如果示例代码需要用到时间戳，因此创建一个示例中临时使用的时间戳组件如下：
+
+```
+📦ex_timestamp
+ ┣ 📜ex_timestamp.h
+ ┣ 📜ex_timestamp_esp32.c
+ ┣ 📜ex_timestamp_ws63.c
+ ┗ 📜xf_collect.py
+```
+
+其中 `xf_collect.py` 的代码如下：
+
+```python
+import xf_build
+
+srcs = []
+incs = ["."]
+reqs = ["xf_utils"]
+
+platform_esp32  = xf_build.get_define("PLATFORM_ESP32")
+platform_ws63   = xf_build.get_define("PLATFORM_WS63")
+if platform_esp32 == "y":
+    srcs.append("ex_timestamp/ex_timestamp_esp32.c")
+    reqs.append("lwip")
+    reqs.append("esp_timer")
+elif platform_ws63 == "y":
+    srcs.append("ex_timestamp/ex_timestamp_ws63.c")
+
+xf_build.collect(srcs=srcs, inc_dirs=incs, requires=reqs)
+```

--- a/examples/example_components/ex_easy_wifi/XFKconfig
+++ b/examples/example_components/ex_easy_wifi/XFKconfig
@@ -1,0 +1,10 @@
+
+config EX_EASY_WIFI_SSID
+    string "SSID of WIFI."
+    default "myssid"
+    help
+        In AP mode, it is the broadcast SSID; in STA mode, it is the target SSID
+
+config EX_EASY_WIFI_PASSWORD
+    string "Password for WIFI."
+    default "mypassword"

--- a/examples/example_components/ex_easy_wifi/ex_easy_wifi.c
+++ b/examples/example_components/ex_easy_wifi/ex_easy_wifi.c
@@ -1,0 +1,408 @@
+/**
+ * @file ex_easy_wifi.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-09-30
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include "ex_easy_wifi.h"
+
+#include "xf_osal.h"
+
+/* ==================== [Defines] =========================================== */
+
+#define EXAMPLE_WIFI_AUTHMODE           XF_WIFI_AUTH_WPA_WPA2_PSK
+#define EXAMPLE_WIFI_CHANNEL            6 /*!< wifi 信道 */
+#define EXAMPLE_WIFI_SSID_HIDDEN_FLAG   0 /*!< 不隐藏 */
+
+/*
+    TODO Kconfig 如果 string 类型输入 "\xaa\xbb\xcc\xdd\xee\xff"
+    要么转义成 "\\xaa\\xbb\\xcc\\xdd\\xee\\xff",
+    要么变成   "xaaxbbxccxddxeexff"
+ */
+#if !defined(EX_EASY_WIFI_AP_MAC)
+#   define EX_EASY_WIFI_AP_MAC          "\x11\x22\x33\x44\x55\x66"
+#endif
+#if !defined(EX_EASY_WIFI_STA_MAC)
+#   define EX_EASY_WIFI_STA_MAC         "\xaa\xbb\xcc\xdd\xee\xff"
+#endif
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static void _wifi_ap_event_handler(
+    xf_wifi_event_id_t event_id, void *event_data, void *user_args);
+static void _wifi_ip_event_handler(
+    xf_ip_event_id_t event_id, void *event_data, void *user_args);
+
+static void _wifi_sta_event_handler(
+    xf_wifi_event_id_t event_id, void *event_data, void *user_args);
+static void _ip_event_handler(
+    xf_ip_event_id_t event_id, void *event_data, void *user_args);
+
+static void _sta_task(void *argument);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "ex_easy_wifi";
+
+/* AP */
+
+static xf_wifi_ap_cfg_ext_t s_ap_cfg_ext = {
+    .b_set_mac      = true,
+    .mac            = EX_EASY_WIFI_AP_MAC,
+};
+static xf_wifi_ap_cfg_t s_ap_cfg = {
+    .ssid           = CONFIG_EX_EASY_WIFI_SSID,
+    .password       = CONFIG_EX_EASY_WIFI_PASSWORD,
+    .authmode       = EXAMPLE_WIFI_AUTHMODE,
+    .channel        = EXAMPLE_WIFI_CHANNEL,
+    .ssid_hidden    = EXAMPLE_WIFI_SSID_HIDDEN_FLAG,
+    .p_cfg_ext      = &s_ap_cfg_ext,    /*!< 配置 mac */
+    .p_static_ip    = NULL,             /*!< 不使用静态 IP */
+};
+static uint8_t s_ap_ip_assigned = false;
+
+/* STA */
+
+static uint8_t s_sta_connected = false;     /*!< 是否已连接 */
+static uint8_t s_sta_got_ip_flag = false;   /*!< 是否获取到 IP */
+
+static xf_wifi_sta_cfg_ext_t s_sta_cfg_ext = {
+    .b_set_mac      = true,
+    .mac            = EX_EASY_WIFI_STA_MAC,
+};
+static xf_wifi_sta_cfg_t s_sta_cfg = {
+    .ssid           = CONFIG_EX_EASY_WIFI_SSID,
+    .password       = CONFIG_EX_EASY_WIFI_PASSWORD,
+    .bssid_set      = false,                /*!< 不配置目标 AP 的 MAC 地址 */
+    .bssid          = {0},
+    .authmode       = EXAMPLE_WIFI_AUTHMODE,
+    .channel        = EXAMPLE_WIFI_CHANNEL,
+    .p_cfg_ext      = &s_sta_cfg_ext,       /*!< 配置 mac */
+    .p_static_ip    = NULL,                 /*!< 不使用静态 IP */
+};
+
+static xf_osal_thread_t s_sta_thread_hdl = NULL;
+#define EX_THREAD_NAME          "ex_sta"
+#define EX_THREAD_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define EX_THREAD_STACK_SIZE    (1024 * 4)
+static const xf_osal_thread_attr_t s_sta_attr = {
+    .name       = EX_THREAD_NAME,
+    .priority   = EX_THREAD_PRIORITY,
+    .stack_size = EX_THREAD_STACK_SIZE,
+};
+
+/* ==================== [Macros] ============================================ */
+
+/* ==================== [Global Functions] ================================== */
+
+xf_err_t ex_easy_wifi_ap(void)
+{
+    XF_ERROR_CHECK(xf_wifi_enable());
+    XF_ERROR_CHECK(xf_wifi_ap_set_cb(_wifi_ap_event_handler, NULL));
+    XF_ERROR_CHECK(xf_wifi_ap_set_ip_cb(_wifi_ip_event_handler, NULL));
+
+    s_ap_cfg.authmode = EXAMPLE_WIFI_AUTHMODE;
+    if (strnlen((const char *)s_ap_cfg.password, XF_WIFI_PASSWORD_LEN_MAX - 1) == 0) {
+        s_ap_cfg.authmode = XF_WIFI_AUTH_OPEN;
+    }
+
+    XF_ERROR_CHECK(xf_wifi_ap_init(&s_ap_cfg));
+
+    while (false == s_ap_ip_assigned) {
+        xf_osal_delay_ms(100);
+    }
+
+    return XF_OK;
+}
+
+xf_ip4_addr_t ex_easy_wifi_ap_get_last_sta_ip(void)
+{
+    xf_ip4_addr_t ip4_addr = {0};
+    xf_wifi_sta_info_t sta_array[8] = {0};
+    uint32_t sta_num = 0;
+    xf_err_t xf_ret = XF_OK;
+    xf_ret = xf_wifi_ap_get_sta_list(sta_array, ARRAY_SIZE(sta_array), &sta_num);
+    if (XF_OK != xf_ret) {
+        XF_LOGE(TAG, "ap_get_sta_list-%s", xf_err_to_name(xf_ret));
+        goto l_err;
+    }
+    if (sta_num > ARRAY_SIZE(sta_array) || (0 == sta_num)) {
+        XF_LOGE(TAG, "sta_num:%d-%s", sta_num, xf_err_to_name(XF_ERR_INVALID_ARG));
+        goto l_err;
+    }
+    xf_netif_t netif_hdl = NULL;
+    xf_ret = xf_wifi_ap_get_netif(&netif_hdl);
+    if (XF_OK != xf_ret) {
+        XF_LOGE(TAG, "ap_get_netif-%s", xf_err_to_name(xf_ret));
+        goto l_err;
+    }
+    xf_netif_pair_mac_ip_t pair_mac_ip[1] = {0};
+    memcpy(pair_mac_ip[0].mac, sta_array[sta_num - 1].mac, ARRAY_SIZE(sta_array[0].mac));
+    xf_ret = xf_netif_dhcps_get_clients_by_mac(
+                 netif_hdl, pair_mac_ip, ARRAY_SIZE(pair_mac_ip));
+    if (XF_OK != xf_ret) {
+        XF_LOGE(TAG, "xf_netif_dhcps_get_clients_by_mac-%s", xf_err_to_name(xf_ret));
+        goto l_err;
+    }
+    ip4_addr.addr = xf_netif_htonl(pair_mac_ip[0].ip.addr);
+    return ip4_addr;
+
+l_err:;
+    return (xf_ip4_addr_t) {
+        0
+    };
+}
+
+xf_ip4_addr_t ex_easy_wifi_ap_get_onw_ip(void)
+{
+    xf_ip4_addr_t ip4_addr = {0};
+    xf_err_t xf_ret = XF_OK;
+    xf_netif_t netif_hdl = NULL;
+    xf_ret = xf_wifi_ap_get_netif(&netif_hdl);
+    if (XF_OK != xf_ret) {
+        XF_LOGE(TAG, "ap_get_netif-%s", xf_err_to_name(xf_ret));
+        goto l_err;
+    }
+    xf_netif_ip_info_t ip_info = {0};
+    xf_ret = xf_netif_get_ip_info(netif_hdl, &ip_info);
+    if (XF_OK != xf_ret) {
+        XF_LOGE(TAG, "get_ip_info-%s", xf_err_to_name(xf_ret));
+        goto l_err;
+    }
+
+    ip4_addr.addr = ip_info.ip.addr;
+    return ip4_addr;
+
+l_err:;
+    return (xf_ip4_addr_t) {
+        0
+    };
+}
+
+xf_err_t ex_easy_wifi_sta(void)
+{
+    XF_ERROR_CHECK(xf_wifi_enable());
+    XF_ERROR_CHECK(xf_wifi_sta_set_cb(_wifi_sta_event_handler, NULL));
+    XF_ERROR_CHECK(xf_wifi_sta_set_ip_cb(_ip_event_handler, NULL));
+
+    s_sta_cfg.authmode = EXAMPLE_WIFI_AUTHMODE;
+    if (strnlen((const char *)s_sta_cfg.password, XF_WIFI_PASSWORD_LEN_MAX) == 0) {
+        s_sta_cfg.authmode = XF_WIFI_AUTH_OPEN;
+    }
+
+    XF_ERROR_CHECK(xf_wifi_sta_init(&s_sta_cfg));
+
+    s_sta_thread_hdl = xf_osal_thread_create(_sta_task, NULL, &s_sta_attr);
+    if (s_sta_thread_hdl == NULL) {
+        XF_LOGE(TAG, "xf_osal_thread_create error");
+        return XF_FAIL;
+    }
+
+    for (;;) {
+        if (true == s_sta_got_ip_flag) {
+            break;
+        }
+        xf_osal_delay_ms(100);
+    }
+
+    return XF_OK;
+}
+
+bool ex_easy_wifi_sta_is_connected(void)
+{
+    return (bool)s_sta_connected;
+}
+
+bool ex_easy_wifi_sta_got_ip(void)
+{
+    return (bool)s_sta_got_ip_flag;
+}
+
+xf_ip4_addr_t ex_easy_wifi_sta_get_gw_ip(void)
+{
+    xf_ip4_addr_t ip4_addr = {0};
+    xf_err_t xf_ret = XF_OK;
+    xf_netif_t netif_hdl = NULL;
+    xf_ret = xf_wifi_sta_get_netif(&netif_hdl);
+    if (XF_OK != xf_ret) {
+        XF_LOGE(TAG, "ap_get_netif-%s", xf_err_to_name(xf_ret));
+        goto l_err;
+    }
+    xf_netif_ip_info_t ip_info = {0};
+    xf_ret = xf_netif_get_ip_info(netif_hdl, &ip_info);
+    if (XF_OK != xf_ret) {
+        XF_LOGE(TAG, "get_ip_info-%s", xf_err_to_name(xf_ret));
+        goto l_err;
+    }
+
+    ip4_addr.addr = ip_info.gw.addr;
+    return ip4_addr;
+
+l_err:;
+    return (xf_ip4_addr_t) {
+        0
+    };
+}
+
+xf_ip4_addr_t ex_easy_wifi_sta_get_onw_ip(void)
+{
+    xf_ip4_addr_t ip4_addr = {0};
+    xf_err_t xf_ret = XF_OK;
+    xf_netif_t netif_hdl = NULL;
+    xf_ret = xf_wifi_sta_get_netif(&netif_hdl);
+    if (XF_OK != xf_ret) {
+        XF_LOGE(TAG, "ap_get_netif-%s", xf_err_to_name(xf_ret));
+        goto l_err;
+    }
+    xf_netif_ip_info_t ip_info = {0};
+    xf_ret = xf_netif_get_ip_info(netif_hdl, &ip_info);
+    if (XF_OK != xf_ret) {
+        XF_LOGE(TAG, "get_ip_info-%s", xf_err_to_name(xf_ret));
+        goto l_err;
+    }
+
+    ip4_addr.addr = ip_info.ip.addr;
+    return ip4_addr;
+l_err:;
+    return (xf_ip4_addr_t) {
+        0
+    };
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static void _sta_task(void *argument)
+{
+    for (;;) {
+        if (false == xf_wifi_sta_is_connected()) {
+            /* 如果填 NULL，则使用 xf_wifi_sta_init() 设置的配置连接 */
+            xf_wifi_sta_connect(NULL);
+            xf_osal_delay_ms(3000);
+        }
+        xf_osal_delay_ms(100);
+    }
+    xf_osal_thread_delete(NULL);
+}
+
+static void _wifi_ap_event_handler(
+    xf_wifi_event_id_t event_id, void *event_data, void *user_args)
+{
+    UNUSED(user_args);
+    switch (event_id) {
+    case XF_WIFI_EVENT_AP_START: {
+        XF_LOGI(TAG, "AP has started.");
+    } break;
+    case XF_WIFI_EVENT_AP_STOP: {
+        XF_LOGI(TAG, "AP has stopped.");
+    } break;
+    case XF_WIFI_EVENT_AP_STA_CONNECTED: {
+        xf_wifi_event_ap_sta_conn_t *e = (xf_wifi_event_ap_sta_conn_t *)event_data;
+        XF_LOGI(TAG, "station "XF_MACSTR" join", XF_MAC2STR(e->mac));
+    } break;
+    case XF_WIFI_EVENT_AP_STA_DISCONNECTED: {
+        xf_wifi_event_ap_sta_disconn_t *e = (xf_wifi_event_ap_sta_disconn_t *)event_data;
+        XF_LOGI(TAG, "station "XF_MACSTR" leave", XF_MAC2STR(e->mac));
+    } break;
+    default:
+        break;
+    }
+}
+
+static void _wifi_ip_event_handler(
+    xf_ip_event_id_t event_id, void *event_data, void *user_args)
+{
+    UNUSED(user_args);
+    switch (event_id) {
+    case XF_IP_EVENT_IP_ASSIGNED: {
+        xf_ip_event_ip_assigned_t *e = (xf_ip_event_ip_assigned_t *)event_data;
+        XF_LOGI(TAG, "Assign ip " XF_IPSTR " to site " XF_MACSTR,
+                XF_IP2STR(&e->ip), XF_MAC2STR(e->mac));
+        s_ap_ip_assigned = true;
+    } break;
+    default:
+        break;
+    }
+}
+
+static void _wifi_sta_event_handler(
+    xf_wifi_event_id_t event_id, void *event_data, void *user_args)
+{
+    UNUSED(user_args);
+
+    switch (event_id) {
+    case XF_WIFI_EVENT_STA_START: {
+        XF_LOGI(TAG, "STA has started.");
+    } break;
+    case XF_WIFI_EVENT_STA_STOP: {
+        s_sta_got_ip_flag = false;
+        XF_LOGI(TAG, "STA has stopped.");
+    } break;
+    case XF_WIFI_EVENT_STA_CONNECTED: {
+        s_sta_connected = true;
+        XF_LOGI(TAG, "The STA is connected to the AP.");
+        xf_wifi_event_sta_conn_t *e = (xf_wifi_event_sta_conn_t *)event_data;
+        XF_LOGI(TAG,
+                "\nssid:      %s\n"
+                "mac:       "XF_MACSTR"\n"
+                "channel:   %d\n"
+                "authmode:  %d",
+                e->ssid, XF_MAC2STR(e->bssid), (int)e->channel, (int)e->authmode);
+    } break;
+    case XF_WIFI_EVENT_STA_DISCONNECTED: {
+        /* 如果之前的状态是已连接 */
+        if (true == s_sta_connected) {
+            s_sta_got_ip_flag = false;
+            s_sta_connected = false;
+            XF_LOGI(TAG, "The STA has been disconnected from the AP.");
+            xf_wifi_event_sta_disconn_t *e = (xf_wifi_event_sta_disconn_t *)event_data;
+            XF_LOGI(TAG,
+                    "\nssid:      %s\n"
+                    "mac:       "XF_MACSTR"\n"
+                    "rssi:      %d",
+                    e->ssid, XF_MAC2STR(e->bssid), (int)e->rssi);
+        }
+    } break;
+    default:
+        break;
+    }
+}
+
+static void _ip_event_handler(
+    xf_ip_event_id_t event_id, void *event_data, void *user_args)
+{
+    switch (event_id) {
+    case XF_IP_EVENT_GOT_IP: {
+        xf_ip_event_got_ip_t *e = (xf_ip_event_got_ip_t *)event_data;
+        XF_LOGI(TAG, "\n"
+                "got ip:       " XF_IPSTR "\n"
+                "got gw:       " XF_IPSTR "\n"
+                "got netmask:  " XF_IPSTR,
+                XF_IP2STR(&e->ip_info.ip),
+                XF_IP2STR(&e->ip_info.gw),
+                XF_IP2STR(&e->ip_info.netmask));
+        s_sta_got_ip_flag = true;
+        if (0 == e->ip_info.gw.addr) {
+            /* TODO 对于 ws63 的默认 at ap(1.10.101)，存在不会分配 gw 的现象 */
+            xf_netif_ip_info_t ip_info = {0};
+            ip_info.ip.addr         = e->ip_info.ip.addr;
+            ip_info.netmask.addr    = e->ip_info.netmask.addr;
+            ip_info.gw.addr = XF_IP4TOADDR(xf_ip4_addr1_16(&e->ip_info.ip),
+                                           xf_ip4_addr2_16(&e->ip_info.ip),
+                                           xf_ip4_addr3_16(&e->ip_info.ip),
+                                           1);
+            xf_netif_set_ip_info(e->netif_hdl, &ip_info);
+        }
+    } break;
+    default:
+        break;
+    }
+}

--- a/examples/example_components/ex_easy_wifi/ex_easy_wifi.h
+++ b/examples/example_components/ex_easy_wifi/ex_easy_wifi.h
@@ -1,0 +1,48 @@
+/**
+ * @file ex_easy_wifi.h
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-09-30
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+#ifndef __EX_EASY_WIFI_H__
+#define __EX_EASY_WIFI_H__
+
+/* ==================== [Includes] ========================================== */
+
+#include "xf_utils.h"
+
+#include "xf_wifi.h"
+#include "xf_netif.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ==================== [Defines] =========================================== */
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Global Prototypes] ================================= */
+
+xf_err_t ex_easy_wifi_ap(void);
+xf_ip4_addr_t ex_easy_wifi_ap_get_last_sta_ip(void);
+xf_ip4_addr_t ex_easy_wifi_ap_get_onw_ip(void);
+
+xf_err_t ex_easy_wifi_sta(void);
+bool ex_easy_wifi_sta_is_connected(void);
+bool ex_easy_wifi_sta_got_ip(void);
+xf_ip4_addr_t ex_easy_wifi_sta_get_gw_ip(void);
+xf_ip4_addr_t ex_easy_wifi_sta_get_onw_ip(void);
+
+/* ==================== [Macros] ============================================ */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* __EX_EASY_WIFI_H__ */

--- a/examples/example_components/ex_easy_wifi/xf_collect.py
+++ b/examples/example_components/ex_easy_wifi/xf_collect.py
@@ -1,0 +1,16 @@
+import xf_build
+
+srcs = [
+    "*.c",
+]
+
+incs = [
+    ".",
+]
+
+reqs = [
+    "xf_utils",
+    "xf_osal",
+]
+
+xf_build.collect(srcs=srcs, inc_dirs=incs, requires=reqs)

--- a/examples/protocols/http_request/README.md
+++ b/examples/protocols/http_request/README.md
@@ -1,0 +1,248 @@
+# http_request - socket 请求 http 报文示例
+
+## 支持情况
+
+1.  espressif
+
+    1.  esp32
+
+1.  nearlink
+
+    1.  ws63
+
+## 示例简述
+
+本示例演示如何使用 xf_wifi 的站点模式 (sta) 连接到 AP，解析域名，建立 socket 连接，并请求 http 报文。
+
+## 如何使用
+
+1.  所需的软件和硬件。
+
+    1.  外部软件包。
+
+        无。
+
+    1.  硬件。
+
+        片内支持 wifi 的芯片，如 esp32、ws63.
+
+1.  配置。
+
+    无特殊配置项。
+
+1.  构建和烧录步骤与要点。
+
+    无。
+
+## 运行现象
+
+在 `ex_easy_wifi_sta()` 内会启动 STA 并尝试连接到目标 AP，直至获取到 IP 后返回。之后输出获取到的域名服务器、解析 `example.com` 域名、创建 socket连接并连接服务器，之后发送 HTTP 请求并接收服务器响应。最后输出接收到的服务器响应信息。
+
+正常情况下
+
+## 常见问题
+
+无。
+
+## 示例平台差异
+
+无。
+
+## 运行日志
+
+以下是 esp32 的运行日志。
+
+```
+I (869)-ex_easy_wifi: STA has started.
+E (1882) wifi:sta is connecting, return error
+E (2892) wifi:sta is connecting, return error
+I (3442) wifi:new:<1,1>, old:<1,0>, ap:<255,255>, sta:<1,1>, prof:6
+I (3444) wifi:state: init -> auth (b0)
+I (3466) wifi:state: auth -> assoc (0)
+I (3475) wifi:state: assoc -> run (10)
+I (3504) wifi:connected with ***, aid = 1, channel 1, 40U, bssid = **:**:**:**:**:**
+I (3505) wifi:security: WPA2-PSK, phy: bgn, rssi: -43
+I (3510) wifi:pm start, type: 0
+
+I (3510) wifi:dp: 1, bi: 102400, li: 3, scale listen interval from 307200 us to 307200 us
+I (3520)-ex_easy_wifi: The STA is connected to the AP.
+I (3523)-ex_easy_wifi:
+ssid:      ***
+mac:       **:**:**:**:**:**
+channel:   1
+authmode:  4
+I (3551) wifi:AP's beacon interval = 102400 us, DTIM period = 1
+I (4126) wifi:<ba-add>idx:0 (ifx:0, **:**:**:**:**:**), tid:0, ssn:0, winSize:64
+I (5019) esp_netif_handlers: sta ip: 192.168.96.47, mask: 255.255.248.0, gw: 192.168.100.1
+I (5020)-ex_easy_wifi:
+got ip:       192.168.96.47
+got gw:       192.168.100.1
+got netmask:  255.255.248.0
+I (5034)-sta: dns main:     *.*.*.*
+I (5034)-sta: dns backup:   *.*.*.*
+I (6425)-sta: Response:
+HTTP/1.1 200 OK
+Age: 476677
+Cache-Control: max-age=604800
+Content-Type: text/html; charset=UTF-8
+Date: Wed, 09 Oct 2024 07:23:28 GMT
+Etag: "3147526947+gzip+ident"
+Expires: Wed, 16 Oct 2024 07:23:28 GMT
+Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
+Server: ECAcc (sac/2559)
+Vary: Accept-Encoding
+X-Cache: HIT
+Content-Length: 1256
+
+<!doctype html>
+<html>
+<head>
+    <title>Example Domain</title>
+
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style type="text/css">
+    body {
+        background-color: #f0f0f2;
+        margin: 0;
+        padding: 0;
+        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+    }
+    div {
+        width: 600px;
+        margin: 5em auto;
+        padding: 2em;
+        background-color: #fdfdff;
+        border-radius: 0.5em;
+        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
+    }
+    a:link, a:visited {
+        color: #38488f;
+        text-decoration: none;
+    }
+    @media (max-width: 700px) {
+        div {
+            margin: 0 auto;
+            width: auto;
+        }
+    }
+    </style>
+</head>
+
+<body>
+<div>
+    <h1>Example Domain</h1>
+    <p>This domain is for use in illustrative examples in documents. You may use this
+    domain in literature without prior coordination or asking for permission.</p>
+    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
+</div>
+</body>
+</html>
+
+```
+
+以下是 ws63 的运行日志。
+
+```
+I (274)-ex_easy_wifi: STA has started.
+Srv:2047: last scantime > 5s, trigger scan
+wifi_sta_connect_fill_scan_param:: Specifying an SSID for scanning
+drv_soc_ioctl ioctl_cmd->cmd=14.
+hmac_single_hal_device_scan_complete:vap[1] time[762] chan_cnt[13] chan_0[1] back[0] event[6] mode[0]
+Scan::vap[1] find bss_num[1] in regdomain, other bss_num[0]
+Srv:548:recive event = 1
+Srv:216:scan triggered by connect!
+Srv:find ssid[PTWSMART] auth type[3] pairwise[1] ft_flag[0]
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=16.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
+drv_soc_ioctl ioctl_cmd->cmd=1.
++NOTICE:CONNECTED
+drv_soc_ioctl ioctl_cmd->cmd=6.
+Srv:548:recive event = 2
+I (1246)-ex_easy_wifi: The STA is connected to the AP.
+I (1251)-ex_easy_wifi:
+ssid:      ***
+mac:       **:**:**:**:**:**
+channel:   1
+authmode:  4
+I (3179)-ex_easy_wifi:
+got ip:       192.168.96.42
+got gw:       192.168.100.1
+got netmask:  255.255.248.0
+I (3198)-sta: dns main:     *.*.*.*
+I (3198)-sta: dns backup:   *.*.*.*
+I (3568)-sta: Response:
+HTTP/1.1 200 OK
+Accept-Ranges: bytes
+Age: 476571
+Cache-Control: max-age=604800
+Content-Type: text/html; charset=UTF-8
+Date: Wed, 09 Oct 2024 07:05:46 GMT
+Etag: "3147526947"
+Expires: Wed, 16 Oct 2024 07:05:46 GMT
+Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
+Server: ECAcc (sac/2527)
+Vary: Accept-Encoding
+X-Cache: HIT
+Content-Length: 1256
+
+<!doctype html>
+<html>
+<head>
+    <title>Example Domain</title>
+
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style type="text/css">
+    body {
+        background-color: #f0f0f2;
+        margin: 0;
+        padding: 0;
+        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+    }
+    div {
+        width: 600px;
+        margin: 5em auto;
+        padding: 2em;
+        background-color: #fdfdff;
+        border-radius: 0.5em;
+        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
+    }
+    a:link, a:visited {
+        color: #38488f;
+        text-decoration: none;
+    }
+    @media (max-width: 700px) {
+        div {
+            margin: 0 auto;
+            width: auto;
+        }
+    }
+    </style>
+</head>
+
+<body>
+<div>
+    <h1>Example Domain</h1>
+    <p>This domain is for use in illustrative examples in documents. You may use this
+    domain in literature without prior coordination or asking for permission.</p>
+    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
+</div>
+</body>
+</html>
+
+```

--- a/examples/protocols/http_request/main/xf_collect.py
+++ b/examples/protocols/http_request/main/xf_collect.py
@@ -1,0 +1,3 @@
+import xf_build
+
+xf_build.collect()

--- a/examples/protocols/http_request/main/xf_main.c
+++ b/examples/protocols/http_request/main/xf_main.c
@@ -1,0 +1,134 @@
+/**
+ * @file xf_main.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-06-06
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include <string.h>
+#include <sys/param.h>
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/netdb.h"
+
+#include <unistd.h>
+#include <arpa/inet.h>
+
+#include "xf_utils.h"
+#include "xf_wifi.h"
+#include "xf_netif.h"
+#include "xf_osal.h"
+#include "xf_task.h"
+
+#include "ex_easy_wifi.h"
+
+/* ==================== [Defines] =========================================== */
+
+#define HTTP_BUFFER_SIZE    (1024 * 2)
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static void _example_thread(void *argument);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "sta";
+static char s_http_buf[HTTP_BUFFER_SIZE];
+
+static xf_osal_thread_t s_thread_hdl = NULL;
+#define EX_THREAD_NAME          "ex_thread"
+#define EX_THREAD_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define EX_THREAD_STACK_SIZE    (1024 * 4)
+static const xf_osal_thread_attr_t s_thread_attr = {
+    .name       = EX_THREAD_NAME,
+    .priority   = EX_THREAD_PRIORITY,
+    .stack_size = EX_THREAD_STACK_SIZE,
+};
+
+/* ==================== [Macros] ============================================ */
+
+/* ==================== [Global Functions] ================================== */
+
+void xf_main(void)
+{
+    s_thread_hdl = xf_osal_thread_create(_example_thread, NULL, &s_thread_attr);
+    if (s_thread_hdl == NULL) {
+        XF_LOGE(TAG, "xf_osal_thread_create error");
+        return;
+    }
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static void _example_thread(void *argument)
+{
+    UNUSED(argument);
+
+    ex_easy_wifi_sta();
+
+    xf_netif_t netif_hdl = NULL;
+    xf_wifi_sta_get_netif(&netif_hdl);
+
+    xf_netif_dns_info_t dns_info = {0};
+    xf_netif_get_dns_info(netif_hdl, XF_NETIF_DNS_MAIN, &dns_info);
+    XF_LOGI(TAG, "dns main:     " XF_IPSTR, XF_IP2STR(&dns_info.ip.u_addr.ip4));
+    xf_netif_get_dns_info(netif_hdl, XF_NETIF_DNS_BACKUP, &dns_info);
+    XF_LOGI(TAG, "dns backup:   " XF_IPSTR, XF_IP2STR(&dns_info.ip.u_addr.ip4));
+
+    int sockfd = 0;
+    struct sockaddr_in server_addr;
+    struct hostent *host;
+    char *hostname = "example.com";
+    char *request = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+
+    /* 解析域名 */
+    if ((host = gethostbyname(hostname)) == NULL) {
+        XF_LOGE(TAG, "gethostbyname failed");
+        goto l_err;
+    }
+
+    /* 创建 socket */
+    if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        XF_LOGE(TAG, "Socket creation failed");
+        goto l_err;
+    }
+
+    /* 设置服务器地址 */
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(80);
+    server_addr.sin_addr.s_addr = *(long *)(host->h_addr);
+
+    /* 连接服务器 */
+    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+        XF_LOGE(TAG, "Connection failed");
+        closesocket(sockfd);
+        goto l_err;
+    }
+
+    /* 发送 HTTP 请求 */
+    send(sockfd, request, strlen(request), 0);
+
+    /* 接收服务器响应 */
+    int bytes_received = recv(sockfd, s_http_buf, HTTP_BUFFER_SIZE - 1, 0);
+    if (bytes_received < 0) {
+        XF_LOGE(TAG, "Receive failed");
+    } else {
+        s_http_buf[bytes_received] = '\0';
+        XF_LOGI(TAG, "Response:\n%s\n", s_http_buf);
+    }
+
+l_err:;
+    /* 关闭 socket */
+    closesocket(sockfd);
+    xf_osal_thread_delete(NULL);
+}

--- a/examples/protocols/http_request/xf_project.py
+++ b/examples/protocols/http_request/xf_project.py
@@ -1,0 +1,11 @@
+import xf_build
+from xf_build import api
+from pathlib import Path
+
+example_components_path: Path = api.XF_ROOT / "examples" / "example_components"
+
+example_components = []
+example_components.append((example_components_path / "ex_easy_wifi").as_posix())
+
+xf_build.project_init(user_dirs=example_components)
+xf_build.program()

--- a/examples/protocols/icmp_echo/README.md
+++ b/examples/protocols/icmp_echo/README.md
@@ -1,0 +1,138 @@
+# icmp_echo - socket ping 示例
+
+## 支持情况
+
+1.  espressif
+
+    1.  esp32
+
+1.  nearlink
+
+    1.  ws63
+
+## 示例简述
+
+本示例演示如何使用 xf_wifi 的站点模式 (sta) 连接到能连接以太网的 ap 后，ping 指定域名。
+
+## 如何使用
+
+1.  所需的软件和硬件。
+
+    1.  外部软件包。
+
+        无。
+
+    1.  硬件。
+
+        片内支持 wifi 的芯片，如 esp32、ws63.
+
+1.  配置。
+
+    无特殊配置项。
+
+1.  构建和烧录步骤与要点。
+
+    无。
+
+## 运行现象
+
+在 `ex_easy_wifi_sta()` 内会启动 STA 并尝试连接到目标 AP，直至获取到 IP 后返回。之后逐个解析域名，并发出 ping 请求。
+
+正常情况下
+
+## 常见问题
+
+无。
+
+## 示例平台差异
+
+无。
+
+## 运行日志
+
+以下是 esp32 的运行日志。
+
+```
+I (3790)-sta: target_addr: 93.184.215.14
+64 bytes from 93.184.215.14 icmp_seq=1 ttl=52 time=258 ms
+64 bytes from 93.184.215.14 icmp_seq=2 ttl=52 time=285 ms
+64 bytes from 93.184.215.14 icmp_seq=3 ttl=52 time=207 ms
+64 bytes from 93.184.215.14 icmp_seq=4 ttl=52 time=232 ms
+64 bytes from 93.184.215.14 icmp_seq=5 ttl=52 time=251 ms
+
+--- 93.184.215.14 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 1233ms
+I (9917)-sta: target_addr: 183.2.172.42
+64 bytes from 183.2.172.42 icmp_seq=1 ttl=52 time=67 ms
+64 bytes from 183.2.172.42 icmp_seq=2 ttl=52 time=21 ms
+64 bytes from 183.2.172.42 icmp_seq=3 ttl=52 time=39 ms
+64 bytes from 183.2.172.42 icmp_seq=4 ttl=52 time=73 ms
+64 bytes from 183.2.172.42 icmp_seq=5 ttl=52 time=20 ms
+
+--- 183.2.172.42 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 220ms
+I (16054)-sta: target_addr: 121.14.77.201
+64 bytes from 121.14.77.201 icmp_seq=1 ttl=52 time=58 ms
+64 bytes from 121.14.77.201 icmp_seq=2 ttl=52 time=29 ms
+64 bytes from 121.14.77.201 icmp_seq=3 ttl=52 time=36 ms
+64 bytes from 121.14.77.201 icmp_seq=4 ttl=52 time=11 ms
+64 bytes from 121.14.77.201 icmp_seq=5 ttl=52 time=15 ms
+
+--- 121.14.77.201 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 149ms
+I (22181)-sta: target_addr: 106.63.103.8
+64 bytes from 106.63.103.8 icmp_seq=1 ttl=50 time=53 ms
+64 bytes from 106.63.103.8 icmp_seq=2 ttl=50 time=52 ms
+64 bytes from 106.63.103.8 icmp_seq=3 ttl=50 time=49 ms
+64 bytes from 106.63.103.8 icmp_seq=4 ttl=50 time=47 ms
+From 106.63.103.8 icmp_seq=5 timeout
+
+--- 106.63.103.8 ping statistics ---
+5 packets transmitted, 4 received, 19% packet loss, time 2200ms
+```
+
+以下是 ws63 的运行日志。
+
+```
+I (2678)-sta: target_addr: 93.184.215.14
+64 bytes from 93.184.215.14 icmp_seq=1 ttl=52 time=178 ms
+64 bytes from 93.184.215.14 icmp_seq=2 ttl=52 time=166 ms
+xo update temp:4,diff:0,xo:0x3083c
+64 bytes from 93.184.215.14 icmp_seq=3 ttl=52 time=162 ms
+I (5203)-ex_easy_wifi:
+got ip:       192.168.96.23
+got gw:       192.168.100.1
+got netmask:  255.255.248.0
+64 bytes from 93.184.215.14 icmp_seq=4 ttl=52 time=168 ms
+64 bytes from 93.184.215.14 icmp_seq=5 ttl=52 time=193 ms
+
+--- 93.184.215.14 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 867ms
+I (8809)-sta: target_addr: 183.2.172.42
+64 bytes from 183.2.172.42 icmp_seq=1 ttl=52 time=26 ms
+64 bytes from 183.2.172.42 icmp_seq=2 ttl=52 time=21 ms
+64 bytes from 183.2.172.42 icmp_seq=3 ttl=52 time=21 ms
+64 bytes from 183.2.172.42 icmp_seq=4 ttl=52 time=48 ms
+64 bytes from 183.2.172.42 icmp_seq=5 ttl=52 time=23 ms
+
+--- 183.2.172.42 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 139ms
+I (14880)-sta: target_addr: 121.14.77.221
+64 bytes from 121.14.77.221 icmp_seq=1 ttl=246 time=17 ms
+64 bytes from 121.14.77.221 icmp_seq=2 ttl=246 time=24 ms
+64 bytes from 121.14.77.221 icmp_seq=3 ttl=246 time=15 ms
+64 bytes from 121.14.77.221 icmp_seq=4 ttl=246 time=29 ms
+64 bytes from 121.14.77.221 icmp_seq=5 ttl=246 time=19 ms
+
+--- 121.14.77.221 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 104ms
+I (20956)-sta: target_addr: 106.63.103.8
+64 bytes from 106.63.103.8 icmp_seq=1 ttl=50 time=55 ms
+64 bytes from 106.63.103.8 icmp_seq=2 ttl=50 time=57 ms
+64 bytes from 106.63.103.8 icmp_seq=3 ttl=50 time=56 ms
+64 bytes from 106.63.103.8 icmp_seq=4 ttl=50 time=49 ms
+64 bytes from 106.63.103.8 icmp_seq=5 ttl=50 time=54 ms
+
+--- 106.63.103.8 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 271ms
+```

--- a/examples/protocols/icmp_echo/main/xf_collect.py
+++ b/examples/protocols/icmp_echo/main/xf_collect.py
@@ -1,0 +1,15 @@
+import xf_build
+
+srcs = [
+    "*.c",
+]
+
+incs = [
+    ".",
+]
+
+reqs = [
+    "ex_easy_wifi",
+]
+
+xf_build.collect(srcs=srcs, inc_dirs=incs, requires=reqs)

--- a/examples/protocols/icmp_echo/main/xf_main.c
+++ b/examples/protocols/icmp_echo/main/xf_main.c
@@ -1,0 +1,178 @@
+/**
+ * @file xf_main.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-06-06
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include <string.h>
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/inet.h"
+#include "lwip/sys.h"
+#include "lwip/netdb.h"
+
+#include "xf_utils.h"
+#include "xf_wifi.h"
+#include "xf_netif.h"
+#include "xf_osal.h"
+
+#include "xf_ping.h"
+
+#include "ex_easy_wifi.h"
+
+/* ==================== [Defines] =========================================== */
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static void _example_thread(void *argument);
+static void xf_ping_cb(
+    xf_ping_event_id_t event_id, xf_ping_t hdl, void *user_args);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "sta";
+
+static xf_osal_thread_t s_thread_hdl = NULL;
+#define EX_THREAD_NAME          "ex_thread"
+#define EX_THREAD_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define EX_THREAD_STACK_SIZE    (1024 * 4)
+static const xf_osal_thread_attr_t s_thread_attr = {
+    .name       = EX_THREAD_NAME,
+    .priority   = EX_THREAD_PRIORITY,
+    .stack_size = EX_THREAD_STACK_SIZE,
+};
+
+static uint8_t s_ping_done = false;
+static const char *const s_hostname_arr[] = {
+    "example.com",
+    "www.baidu.com",
+    "www.qq.com",
+    "www.360.com",
+};
+
+/* ==================== [Macros] ============================================ */
+
+#define ERROR_CHECK(e) \
+    do { \
+        if (unlikely((e) != XF_OK)) { \
+            XF_LOGE(TAG, "An error occurred: %s", XSTR(e != XF_OK)); \
+            while(1); \
+        } \
+    } while (0)
+#define TEST_XF_OK(e) ERROR_CHECK(e)
+
+/* ==================== [Global Functions] ================================== */
+
+void xf_main(void)
+{
+    s_thread_hdl = xf_osal_thread_create(_example_thread, NULL, &s_thread_attr);
+    if (s_thread_hdl == NULL) {
+        XF_LOGE(TAG, "xf_osal_thread_create error");
+        return;
+    }
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static void xf_ping_cb(
+    xf_ping_event_id_t event_id, xf_ping_t hdl, void *user_args)
+{
+    UNUSED(user_args);
+    switch (event_id) {
+    case XF_PING_EVENT_SUCC: {
+        xf_printf("%d bytes from " XF_IPSTR " icmp_seq=%d ttl=%d time=%d ms" "\n",
+                  hdl->recv_len, XF_IP2STR(&hdl->recv_addr.u_addr.ip4),
+                  hdl->packet_hdr->seqno, hdl->ttl, hdl->elapsed_time_ms);
+    } break;
+    case XF_PING_EVENT_TIMEOUT: {
+        xf_printf("From " XF_IPSTR " icmp_seq=%d timeout" "\n",
+                  XF_IP2STR(&hdl->recv_addr.u_addr.ip4), hdl->packet_hdr->seqno);
+    } break;
+    case XF_PING_EVENT_END: {
+        uint32_t loss = (uint32_t)((1 - ((float)hdl->received) / hdl->transmitted) * 100);
+        if (IP_IS_V4(&hdl->recv_addr)) {
+            struct in_addr ip4;
+            ip4.s_addr = hdl->recv_addr.u_addr.ip4.addr;
+            xf_printf("\n--- %s ping statistics ---\n", inet_ntoa(ip4));
+        } else {
+            xf_printf("\n--- %s ping statistics ---\n", inet6_ntoa(*ip_2_ip6(&hdl->recv_addr)));
+        }
+        xf_printf("%d packets transmitted, %d received, %d%% packet loss, time %dms" "\n",
+                  hdl->transmitted, hdl->received, loss, hdl->total_time_ms);
+        s_ping_done = true;
+    } break;
+    default:
+        break;
+    }
+}
+
+static void _example_thread(void *argument)
+{
+    UNUSED(argument);
+
+    ex_easy_wifi_sta();
+
+    xf_netif_t netif_hdl = NULL;
+    xf_wifi_sta_get_netif(&netif_hdl);
+
+    xf_netif_dns_info_t dns_info = {0};
+    xf_netif_get_dns_info(netif_hdl, XF_NETIF_DNS_MAIN, &dns_info);
+    XF_LOGI(TAG, "dns main:     " XF_IPSTR, XF_IP2STR(&dns_info.ip.u_addr.ip4));
+    xf_netif_get_dns_info(netif_hdl, XF_NETIF_DNS_BACKUP, &dns_info);
+    XF_LOGI(TAG, "dns backup:   " XF_IPSTR, XF_IP2STR(&dns_info.ip.u_addr.ip4));
+
+    for (size_t hostname_idx = 0;
+            hostname_idx < ARRAY_SIZE(s_hostname_arr);
+            hostname_idx++) {
+
+        xf_ip4_addr_t dest_ip4 = {0};
+        struct hostent *host;
+        ip_addr_t target_addr = {0};
+
+        /* 解析域名 */
+        if ((host = gethostbyname(s_hostname_arr[hostname_idx])) == NULL) {
+            XF_LOGE(TAG, "gethostbyname failed");
+            dest_ip4 = ex_easy_wifi_sta_get_gw_ip();
+            *(uint32_t *)(host->h_addr) = dest_ip4.addr;
+        }
+        dest_ip4.addr = *(uint32_t *)(host->h_addr);
+
+        target_addr.u_addr.ip4.addr = dest_ip4.addr;
+        target_addr.type = IPADDR_TYPE_V4;
+        XF_LOGI(TAG, "target_addr: " XF_IPSTR,
+                XF_IP2STR(&target_addr.u_addr.ip4));
+
+        xf_ping_cfg_t ping_cfg = XF_PING_DEFAULT_CONFIG();
+        ping_cfg.timeout_ms  = 2000;
+        ping_cfg.target_addr = target_addr;
+        ping_cfg.count       = 5;
+        ping_cfg.interval_ms = 1000;
+
+        xf_ping_t ping_hdl = NULL;
+        TEST_XF_OK(xf_ping_new_session(
+                       &ping_cfg, xf_ping_cb, NULL,
+                       &ping_hdl));
+        TEST_XF_OK(xf_ping_start(ping_hdl));
+
+        while (s_ping_done == false) {
+            xf_osal_delay_ms(100);
+        }
+        s_ping_done = false;
+
+        TEST_XF_OK(xf_ping_delete_session(ping_hdl));
+
+        xf_osal_delay_ms(1000);
+    } /* for 0 ~ ARRAY_SIZE(s_hostname_arr) */
+
+    xf_osal_thread_delete(NULL);
+}

--- a/examples/protocols/icmp_echo/xf_project.py
+++ b/examples/protocols/icmp_echo/xf_project.py
@@ -1,0 +1,11 @@
+import xf_build
+from xf_build import api
+from pathlib import Path
+
+example_components_path: Path = api.XF_ROOT / "examples" / "example_components"
+
+example_components = []
+example_components.append((example_components_path / "ex_easy_wifi").as_posix())
+
+xf_build.project_init(user_dirs=example_components)
+xf_build.program()

--- a/examples/protocols/iperf/softap/README.md
+++ b/examples/protocols/iperf/softap/README.md
@@ -1,0 +1,242 @@
+# wifi_iperf:softap - wifi ap iperf 示例
+
+## 支持情况
+
+1.  espressif
+
+    1.  esp32
+
+1.  nearlink
+
+    1.  ws63
+
+## 示例简述
+
+本示例演示启动 wifi ap 后默认启动 iperf udp 服务端，待客户端连接后输出带宽信息.
+
+通过 `xf menuconfig` 可以配置 iperf 协议与 iperf 角色（服务端/客户端）。
+
+## 如何使用
+
+1.  所需的软件和硬件。
+
+    1.  外部软件包。
+
+        无。
+
+    1.  硬件。
+
+        片内支持 wifi 的芯片，如 esp32、ws63.
+
+1.  配置。
+
+    无特殊配置项。
+
+1.  构建和烧录步骤与要点。
+
+    无。
+
+## 运行现象
+
+本示例启动 ap 等到 sta 连接后，会每秒输出一次带宽信息。
+
+## 常见问题
+
+无。
+
+## 示例平台差异
+
+此示例对以下目标无明显差异：
+
+1. esp32
+1. ws63
+
+## 运行日志
+
+以下是 esp32 的运行日志。
+
+```
+I (284)-ex_easy_wifi: AP has started.
+I (3854) wifi:new:<6,1>, old:<6,1>, ap:<6,1>, sta:<255,255>, prof:6
+I (3856) wifi:station: aa:bb:cc:dd:ee:ff join, AID=1, bgn, 40U
+I (3329)-ex_easy_wifi: station aa:bb:cc:dd:ee:ff join
+I (3926) esp_netif_lwip: DHCP server assigned IP to a client, IP is: 192.168.4.2
+I (3368)-ex_easy_wifi: Assign ip 192.168.4.2 to site aa:bb:cc:dd:ee:ff
+I (3382)-xf_main:
+src_ip4:       192.168.4.1
+dest_ip4:      192.168.4.2
+I (6383)-xf_main: mode=udp-server sip=192.168.4.1:5001,dip=192.168.4.2:5001,interval=1, time=10
+I (6384)-iperf: Socket created
+I (6386)-iperf: Socket bound, port 35091
+I (8072) wifi:<ba-add>idx:2 (ifx:1, aa:bb:cc:dd:ee:ff), tid:0, ssn:0, winSize:64
+
+        Interval Bandwidth
+   0-   1 sec       3.93 Mbits/sec
+   1-   2 sec       4.75 Mbits/sec
+   2-   3 sec       5.95 Mbits/sec
+   3-   4 sec       4.93 Mbits/sec
+   4-   5 sec       5.16 Mbits/sec
+   5-   6 sec       6.60 Mbits/sec
+   6-   7 sec       6.84 Mbits/sec
+   7-   8 sec       4.79 Mbits/sec
+   8-   9 sec       5.09 Mbits/sec
+   9-  10 sec       5.10 Mbits/sec
+   0-  10 sec       5.31 Mbits/sec
+I (17528)-iperf: Udp socket server is closed.
+I (17529)-iperf: iperf done
+I (20584)-xf_main: mode=tcp-server sip=192.168.4.1:5001,dip=192.168.4.2:5001,interval=1, time=10
+I (20585)-iperf: Socket created
+I (20696)-iperf: accept: 192.168.4.2,53216
+
+
+        Interval Bandwidth
+   0-   1 sec       2.92 Mbits/sec
+   1-   2 sec       3.31 Mbits/sec
+   2-   3 sec       3.11 Mbits/sec
+   3-   4 sec       3.21 Mbits/sec
+   4-   5 sec       2.90 Mbits/sec
+   5-   6 sec       3.14 Mbits/sec
+   6-   7 sec       2.79 Mbits/sec
+   7-   8 sec       3.27 Mbits/sec
+   8-   9 sec       2.88 Mbits/sec
+   9-  10 sec       3.40 Mbits/sec
+   0-  10 sec       3.09 Mbits/sec
+I (30715)-iperf: TCP Socket server is closed.
+I (30716)-iperf: iperf done
+I (33885)-xf_main: mode=udp-client sip=192.168.4.1:5001,dip=192.168.4.2:5001,interval=1, time=10
+I (33886)-iperf: Socket created, sending to 192.168.4.2:5001
+
+        Interval Bandwidth
+   0-   1 sec       14.39 Mbits/sec
+   1-   2 sec       2.16 Mbits/sec
+   2-   3 sec       15.00 Mbits/sec
+   3-   4 sec       15.89 Mbits/sec
+   4-   5 sec       14.37 Mbits/sec
+   5-   6 sec       13.91 Mbits/sec
+   6-   7 sec       15.48 Mbits/sec
+   7-   8 sec       14.53 Mbits/sec
+   8-   9 sec       16.14 Mbits/sec
+   9-  10 sec       12.66 Mbits/sec
+   0-  10 sec       13.45 MI (43909)-iperf: UDP Socket client is closed
+bits/sec
+I (43910)-iperf: iperf done
+I (47087)-xf_main: mode=tcp-client sip=192.168.4.1:5001,dip=192.168.4.2:5001,interval=1, time=10
+I (47294)-iperf: Successfully connected
+
+        Interval Bandwidth
+   0-   1 sec       3.27 Mbits/sec
+   1-   2 sec       3.53 Mbits/sec
+   2-   3 sec       3.01 Mbits/sec
+   3-   4 sec       3.14 Mbits/sec
+   4-   5 sec       3.40 Mbits/sec
+   5-   6 sec       2.88 Mbits/sec
+   6-   7 sec       3.01 Mbits/sec
+   7-   8 sec       3.14 Mbits/sec
+   8-   9 sec       3.27 Mbits/sec
+   9-  10 sec       2.62 Mbits/sec
+   0-  10 sec       3.13 Mbits/sec
+I (57306)-iperf: TCP Socket client is closed.
+I (57307)-iperf: iperf done
+I (57388)-xf_main: test done!
+```
+
+以下是 ws63 的运行日志。
+
+```
+I (232)-ex_easy_wifi: AP has started.
+drv_soc_ioctl ioctl_cmd->cmd=2.
+
+drv_soc_ioctl ioctl_cmd->cmd=2.
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
++NOTICE:STA CONNECTED
+drv_soc_ioctl ioctl_cmd->cmd=6.
+Srv:548:recive event = 11
+Srv:2781:sta_num[1]!!
+I (1224)-ex_easy_wifi: station aa:bb:cc:dd:ee:ff join
+I (1680)-ex_easy_wifi: Assign ip 192.168.4.2 to site aa:bb:cc:dd:ee:ff
+Srv:2781:sta_num[1]!!
+I (1741)-xf_main:
+src_ip4:       192.168.4.1
+dest_ip4:      192.168.4.2
+xo update temp:4,diff:0,xo:0x30b3c
+I (4740)-xf_main: mode=udp-server sip=192.168.4.1:5001,dip=192.168.4.2:5001,interval=1, time=10
+I (4744)-iperf: Socket created
+I (4748)-iperf: Socket bound, port 35091
+
+        Interval Bandwidth
+   0-   1 sec       22.30 Mbits/sec
+   1-   2 sec       23.73 Mbits/sec
+   2-   3 sec       28.02 Mbits/sec
+   3-   4 sec       28.25 Mbits/sec
+   4-   5 sec       26.17 Mbits/sec
+   5-   6 sec       28.22 Mbits/sec
+   6-   7 sec       28.69 Mbits/sec
+   7-   8 sec       27.74 Mbits/sec
+   8-   9 sec       27.63 Mbits/sec
+   9-  10 sec       27.55 Mbits/sec
+   0-  10 sec       26.83 Mbits/sec
+I (15785)-iperf: Udp socket server is closed.
+I (15788)-iperf: iperf done
+I (18861)-xf_main: mode=tcp-server sip=192.168.4.1:5001,dip=192.168.4.2:5001,interval=1, time=10
+I (18865)-iperf: Socket created
+I (19131)-iperf: accept: 192.168.4.2,64210
+
+
+        Interval Bandwidth
+   0-   1 sec       6.83 Mbits/sec
+   1-   2 sec       6.58 Mbits/sec
+   2-   3 sec       6.94 Mbits/sec
+   3-   4 sec       6.30 Mbits/sec
+   4-   5 sec       7.22 Mbits/sec
+   5-   6 sec       7.14 Mbits/sec
+   6-   7 sec       7.41 Mbits/sec
+   7-   8 sec       7.26 Mbits/sec
+   8-   9 sec       7.35 Mbits/sec
+   9-  10 sec       7.17 Mbits/sec
+   0-  10 sec       7.02 Mbits/sec
+I (29176)-iperf: TCP Socket server is closed.
+I (29176)-iperf: iperf done
+I (32291)-xf_main: mode=udp-client sip=192.168.4.1:5001,dip=192.168.4.2:5001,interval=1, time=10
+I (32295)-iperf: Socket created, sending to 192.168.4.2:5001
+
+        Interval Bandwidth
+   0-   1 sec       36.66 Mbits/sec
+   1-   2 sec       32.44 Mbits/sec
+   2-   3 sec       40.08 Mbits/sec
+   3-   4 sec       31.92 Mbits/sec
+   4-   5 sec       34.26 Mbits/sec
+   5-   6 sec       36.07 Mbits/sec
+   6-   7 sec       31.15 Mbits/sec
+   7-   8 sec       30.37 Mbits/sec
+   8-   9 sec       32.15 Mbits/sec
+   9-  10 sec       30.71 Mbits/sec
+   0-  10 sec       33.58 Mbits/sec
+I (42523)-iperf: UDP Socket client is closed
+I (42529)-iperf: iperf done
+I (45722)-xf_main: mode=tcp-client sip=192.168.4.1:5001,dip=192.168.4.2:5001,interval=1, time=10
+I (45735)-iperf: Successfully connected
+
+        Interval Bandwidth
+   0-   1 sec       7.47 Mbits/sec
+   1-   2 sec       7.73 Mbits/sec
+   2-   3 sec       7.73 Mbits/sec
+   3-   4 sec       7.99 Mbits/sec
+   4-   5 sec       7.99 Mbits/sec
+   5-   6 sec       7.20 Mbits/sec
+   6-   7 sec       7.73 Mbits/sec
+   7-   8 sec       7.86 Mbits/sec
+   8-   9 sec       8.25 Mbits/sec
+   9-  10 sec       7.99 Mbits/sec
+   0-  10 sec       7.79 Mbits/sec
+I (55779)-iperf: TCP Socket client is closed.
+I (55779)-iperf: iperf done
+I (55862)-xf_main: test done!
+```

--- a/examples/protocols/iperf/softap/main/XFKconfig
+++ b/examples/protocols/iperf/softap/main/XFKconfig
@@ -1,0 +1,23 @@
+
+config EXAMPLE_IPERF_TIME
+    int "Set the iperf running time (unit: second)."
+    default 10
+
+config EXAMPLE_IPERF_AUTO_TEST
+    bool "iperf automatically switches roles and protocols for testing."
+    default y
+    help
+        iperf automatically switches roles and protocols for testing. 
+        If you select No, you need to manually select the role and protocol of iperf.
+
+if !EXAMPLE_IPERF_AUTO_TEST
+
+    config EXAMPLE_IPERF_SELECT_SERVER
+        bool "iperf selects the server. Otherwise, select the client."
+        default y
+
+    config EXAMPLE_IPERF_SELECT_UDP
+        bool "iperf Indicates the udp protocol. Otherwise, tcp is selected."
+        default y
+
+endif # !EXAMPLE_IPERF_AUTO_TEST

--- a/examples/protocols/iperf/softap/main/xf_collect.py
+++ b/examples/protocols/iperf/softap/main/xf_collect.py
@@ -1,0 +1,3 @@
+import xf_build
+
+xf_build.collect()

--- a/examples/protocols/iperf/softap/main/xf_main.c
+++ b/examples/protocols/iperf/softap/main/xf_main.c
@@ -1,0 +1,182 @@
+/**
+ * @file xf_main.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-06-06
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include "xfconfig.h"
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/inet.h"
+
+#include "xf_utils.h"
+#include "xf_wifi.h"
+#include "xf_netif.h"
+#include "xf_osal.h"
+#include "xf_sys.h"
+
+#include "xf_iperf.h"
+
+#include "ex_easy_wifi.h"
+
+/* ==================== [Defines] =========================================== */
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static void _example_thread(void *argument);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "xf_main";
+
+static xf_osal_thread_t s_thread_hdl = NULL;
+#define EX_THREAD_NAME          "ex_thread"
+#define EX_THREAD_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define EX_THREAD_STACK_SIZE    (1024 * 4)
+static const xf_osal_thread_attr_t s_thread_attr = {
+    .name       = EX_THREAD_NAME,
+    .priority   = EX_THREAD_PRIORITY,
+    .stack_size = EX_THREAD_STACK_SIZE,
+};
+
+#ifdef CONFIG_EXAMPLE_IPERF_AUTO_TEST
+static const uint32_t s_iperf_test_item[] = {
+    IPERF_FLAG_SERVER | IPERF_FLAG_UDP,
+    IPERF_FLAG_SERVER | IPERF_FLAG_TCP,
+    IPERF_FLAG_CLIENT | IPERF_FLAG_UDP,
+    IPERF_FLAG_CLIENT | IPERF_FLAG_TCP,
+};
+#endif /* CONFIG_EXAMPLE_IPERF_AUTO_TEST */
+
+/* ==================== [Macros] ============================================ */
+
+/* ==================== [Global Functions] ================================== */
+
+void xf_main(void)
+{
+    s_thread_hdl = xf_osal_thread_create(_example_thread, NULL, &s_thread_attr);
+    if (s_thread_hdl == NULL) {
+        XF_LOGE(TAG, "xf_osal_thread_create error");
+        return;
+    }
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static void _example_thread(void *argument)
+{
+    UNUSED(argument);
+
+    uint32_t test_idx = 0;
+
+    xf_ip4_addr_t dest_ip4 = {0};
+    xf_ip4_addr_t src_ip4 = {0};
+
+    ex_easy_wifi_ap();
+    src_ip4 = ex_easy_wifi_ap_get_onw_ip();
+    dest_ip4 = ex_easy_wifi_ap_get_last_sta_ip();
+
+    XF_LOGI(TAG, "\n"
+            "src_ip4:       " XF_IPSTR "\n"
+            "dest_ip4:      " XF_IPSTR,
+            XF_IP2STR(&src_ip4),
+            XF_IP2STR(&dest_ip4));
+
+    xf_sys_watchdog_disable();
+
+    for (test_idx = 0; test_idx < ARRAY_SIZE(s_iperf_test_item); ++test_idx) {
+        xf_osal_delay_ms(IPERF_SOCKET_RX_TIMEOUT_MS);
+        xf_iperf_stop();
+
+        xf_iperf_cfg_t cfg  = XF_IPERF_DEFAULT_CONFIG();
+        cfg.type            = IPERF_IP_TYPE_IPV4;
+        cfg.time            = CONFIG_EXAMPLE_IPERF_TIME;
+        cfg.destination_ip4 = dest_ip4.addr;
+        cfg.source_ip4      = src_ip4.addr;
+
+#ifdef CONFIG_EXAMPLE_IPERF_AUTO_TEST
+        if (s_iperf_test_item[test_idx] & IPERF_FLAG_CLIENT) {
+            /* 延迟一会，避免服务端还没建立 */
+            xf_osal_delay_ms(100);
+        }
+        cfg.flag = s_iperf_test_item[test_idx];
+#else
+#   if defined(CONFIG_EXAMPLE_IPERF_SELECT_SERVER)
+        cfg.flag |= IPERF_FLAG_SERVER;
+#   else
+        cfg.flag |= IPERF_FLAG_CLIENT;
+#   endif
+#   if defined(CONFIG_EXAMPLE_IPERF_SELECT_UDP)
+        cfg.flag |= IPERF_FLAG_UDP;
+#   else
+        cfg.flag |= IPERF_FLAG_TCP;
+#   endif
+#endif /* CONFIG_EXAMPLE_IPERF_AUTO_TEST */
+
+        XF_LOGI(TAG,
+                "mode=%s-%s sip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
+                "dip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
+                "interval=%" PRId32 ", time=%" PRId32 "",
+                cfg.flag & IPERF_FLAG_TCP ? "tcp" : "udp",
+                cfg.flag & IPERF_FLAG_SERVER ? "server" : "client",
+                cfg.source_ip4 & 0xFF, (cfg.source_ip4 >> 8) & 0xFF, (cfg.source_ip4 >> 16) & 0xFF,
+                (cfg.source_ip4 >> 24) & 0xFF, cfg.sport,
+                cfg.destination_ip4 & 0xFF, (cfg.destination_ip4 >> 8) & 0xFF,
+                (cfg.destination_ip4 >> 16) & 0xFF, (cfg.destination_ip4 >> 24) & 0xFF, cfg.dport,
+                cfg.interval, cfg.time);
+
+        xf_iperf_start(&cfg, NULL, NULL);
+
+        while (xf_iperf_is_running()) {
+            xf_osal_delay_ms(100);
+        }
+    } /* for */
+
+    XF_LOGI(TAG, "test done!");
+
+    xf_osal_thread_delete(NULL);
+}
+
+// /**
+//  * @brief iperf 回调函数。
+//  *
+//  * 这是 iperf 回调示例，如果不需要 iperf 内部报告，
+//  * 则需要修改 `xf_iperf_cfg_t.report_enabled = false;
+//  * 并使用该回调 `xf_iperf_start(&cfg, _xf_iperf_cb, NULL);`
+//  *
+//  * @param event_id iperf 事件 id.
+//  * @param hdl iperf 句柄。
+//  * @param user_args 用户数据。
+//  */
+// static void _xf_iperf_cb(
+//     xf_iperf_event_id_t event_id, xf_iperf_t hdl, void *user_args)
+// {
+//     UNUSED(user_args);
+//     switch (event_id) {
+//     case XF_IPERF_EVENT_START: {
+//         XF_LOGI(TAG, "%16s %s", "Interval", "Bandwidth");
+//     } break;
+//     case XF_IPERF_EVENT_REPORT: {
+//         XF_LOGI(TAG, "%4d-%4d sec       %.2f Mbits/sec",
+//                 hdl->curr_time, hdl->curr_time + hdl->cfg.interval,
+//                 hdl->actual_bandwidth);
+//     } break;
+//     case XF_IPERF_EVENT_END: {
+//         XF_LOGI(TAG, "%4d-%4d sec       %.2f Mbits/sec",
+//                 0, hdl->cfg.time, hdl->average_bandwidth);
+//     } break;
+//     default:
+//         break;
+//     }
+// }

--- a/examples/protocols/iperf/softap/xf_project.py
+++ b/examples/protocols/iperf/softap/xf_project.py
@@ -1,0 +1,11 @@
+import xf_build
+from xf_build import api
+from pathlib import Path
+
+example_components_path: Path = api.XF_ROOT / "examples" / "example_components"
+
+example_components = []
+example_components.append((example_components_path / "ex_easy_wifi").as_posix())
+
+xf_build.project_init(user_dirs=example_components)
+xf_build.program()

--- a/examples/protocols/iperf/softap/xfconfig.defaults
+++ b/examples/protocols/iperf/softap/xfconfig.defaults
@@ -1,0 +1,2 @@
+# Welcome to xfusion
+CONFIG_XF_HEAP_STATIC_SIZE=20480

--- a/examples/protocols/iperf/station/README.md
+++ b/examples/protocols/iperf/station/README.md
@@ -1,0 +1,275 @@
+# wifi_iperf:station - wifi sta iperf 示例
+
+## 支持情况
+
+1.  espressif
+
+    1.  esp32
+
+1.  nearlink
+
+    1.  ws63
+
+## 示例简述
+
+本示例演示 wifi 连接到 ap 后默认启动 iperf udp 客户端并输出带宽信息.
+
+通过 `xf menuconfig` 可以配置 iperf 协议与 iperf 角色（服务端/客户端）。
+
+## 如何使用
+
+1.  所需的软件和硬件。
+
+    1.  外部软件包。
+
+        无。
+
+    1.  硬件。
+
+        片内支持 wifi 的芯片，如 esp32、ws63.
+
+1.  配置。
+
+    无特殊配置项。
+
+1.  构建和烧录步骤与要点。
+
+    无。
+
+## 运行现象
+
+本示例连接到 ap 后，会每秒输出一次带宽信息。
+
+## 常见问题
+
+无。
+
+## 示例平台差异
+
+此示例对以下目标无明显差异：
+
+1. esp32
+1. ws63
+
+## 运行日志
+
+以下是 esp32 的运行日志。
+
+```
+I (279)-ex_easy_wifi: STA has started.
+I (15679) wifi:new:<6,1>, old:<1,0>, ap:<255,255>, sta:<6,1>, prof:6
+I (15681) wifi:state: init -> auth (b0)
+I (15689) wifi:state: auth -> assoc (0)
+I (15700) wifi:state: assoc -> run (10)
+I (15725) wifi:connected with myssid, aid = 1, channel 6, 40U, bssid = 08:3a:f2:bf:1a:39
+I (15726) wifi:security: WPA2-PSK, phy: bgn, rssi: -14
+I (15731) wifi:pm start, type: 1
+
+I (15731) wifi:dp: 1, bi: 102400, li: 3, scale listen interval from 307200 us to 307200 us
+I (15183)-ex_easy_wifi: The STA is connected to the AP.
+I (15186)-ex_easy_wifi: 
+ssid:      myssid
+mac:       08:3a:f2:bf:1a:39
+channel:   6
+authmode:  4
+I (15763) wifi:dp: 2, bi: 102400, li: 4, scale listen interval from 307200 us to 409600 us
+I (15764) wifi:AP's beacon interval = 102400 us, DTIM period = 2
+I (16744) esp_netif_handlers: sta ip: 192.168.4.2, mask: 255.255.255.0, gw: 192.168.4.1
+I (16186)-ex_easy_wifi: 
+got ip:       192.168.4.2
+got gw:       192.168.4.1
+got netmask:  255.255.255.0
+I (16196)-xf_main: 
+src_ip4:       192.168.4.2
+dest_ip4:      192.168.4.1
+I (19301)-xf_main: mode=udp-client sip=192.168.4.2:5001,dip=192.168.4.1:5001,interval=1, time=10
+I (19303)-iperf: Socket created, sending to 192.168.4.1:5001
+
+        Interval Bandwidth
+I (19906) wifi:<ba-add>idx:0 (ifx:0, 08:3a:f2:bf:1a:39), tid:0, ssn:0, winSize:64
+   0-   1 sec       4.68 Mbits/sec
+   1-   2 sec       4.98 Mbits/sec
+   2-   3 sec       6.51 Mbits/sec
+   3-   4 sec       5.26 Mbits/sec
+   4-   5 sec       5.23 Mbits/sec
+   5-   6 sec       6.84 Mbits/sec
+   6-   7 sec       6.91 Mbits/sec
+   7-   8 sec       5.15 Mbits/sec
+   8-   9 sec       5.20 Mbits/sec
+   9-  10 sec       5.09 Mbits/sec
+   0-  10 sec       5.58 Mbits/sec
+I (29322)-iperf: UDP Socket client is closed
+I (29323)-iperf: iperf done
+I (32503)-xf_main: mode=tcp-client sip=192.168.4.2:5001,dip=192.168.4.1:5001,interval=1, time=10
+I (32519)-iperf: Successfully connected
+
+        Interval Bandwidth
+   0-   1 sec       2.75 Mbits/sec
+   1-   2 sec       3.40 Mbits/sec
+   2-   3 sec       3.14 Mbits/sec
+   3-   4 sec       3.27 Mbits/sec
+   4-   5 sec       2.88 Mbits/sec
+   5-   6 sec       3.01 Mbits/sec
+   6-   7 sec       2.75 Mbits/sec
+   7-   8 sec       3.14 Mbits/sec
+   8-   9 sec       2.88 Mbits/sec
+   9-  10 sec       3.40 Mbits/sec
+   0-  10 sec       3.06 Mbits/sec
+I (42553)-iperf: TCP Socket client is closed.
+I (42554)-iperf: iperf done
+I (45604)-xf_main: mode=udp-server sip=192.168.4.2:5001,dip=192.168.4.1:5001,interval=1, time=10
+I (45605)-iperf: Socket created
+I (45607)-iperf: Socket bound, port 35091
+
+        Interval Bandwidth
+   0-   1 sec       9.27 Mbits/sec
+   1-   2 sec       3.21 Mbits/sec
+   2-   3 sec       13.20 Mbits/sec
+   3-   4 sec       12.97 Mbits/sec
+   4-   5 sec       13.44 Mbits/sec
+   5-   6 sec       11.53 Mbits/sec
+   6-   7 sec       13.08 Mbits/sec
+   7-   8 sec       11.80 Mbits/sec
+   8-   9 sec       14.31 Mbits/sec
+   9-  10 sec       11.61 Mbits/sec
+   0-  10 sec       11.44 Mbits/sec
+I (55622)-iperf: Udp socket server is closed.
+I (55625)-iperf: iperf done
+I (58706)-xf_main: mode=tcp-server sip=192.168.4.2:5001,dip=192.168.4.1:5001,interval=1, time=10
+I (58708)-iperf: Socket created
+I (59135)-iperf: accept: 192.168.4.1,60582
+
+
+        Interval Bandwidth
+   0-   1 sec       3.39 Mbits/sec
+   1-   2 sec       3.42 Mbits/sec
+   2-   3 sec       3.06 Mbits/sec
+   3-   4 sec       3.21 Mbits/sec
+   4-   5 sec       3.29 Mbits/sec
+   5-   6 sec       2.90 Mbits/sec
+   6-   7 sec       2.97 Mbits/sec
+   7-   8 sec       3.28 Mbits/sec
+   8-   9 sec       3.15 Mbits/sec
+   9-  10 sec       2.70 Mbits/sec
+   0-  10 sec       3.14 Mbits/sec
+I (69148)-iperf: TCP Socket server is closed.
+I (69149)-iperf: iperf done
+I (69208)-xf_main: test done!
+```
+
+以下是 ws63 的运行日志。
+
+```
+I (225)-ex_easy_wifi: STA has started.
+Srv:2047: last scantime > 5s, trigger scan
+wifi_sta_connect_fill_scan_param:: Specifying an SSID for scanning
+drv_soc_ioctl ioctl_cmd->cmd=14.
+hmac_single_hal_device_scan_complete:vap[1] time[762] chan_cnt[13] chan_0[1] back[0] event[6] mode[0]
+Scan::vap[1] find bss_num[1] in regdomain, other bss_num[0]
+Srv:548:recive event = 1
+Srv:216:scan triggered by connect!
+Srv:find ssid[myssid] auth type[3] pairwise[3] ft_flag[0]
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=16.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
+drv_soc_ioctl ioctl_cmd->cmd=1.
++NOTICE:CONNECTED
+drv_soc_ioctl ioctl_cmd->cmd=6.
+Srv:548:recive event = 2
+I (1215)-ex_easy_wifi: The STA is connected to the AP.
+I (1220)-ex_easy_wifi: 
+ssid:      myssid
+mac:       b6:00:73:89:71:79
+channel:   6
+authmode:  4
+I (2631)-ex_easy_wifi: 
+got ip:       192.168.4.2
+got gw:       192.168.4.1
+got netmask:  255.255.255.0
+I (2650)-xf_main: 
+src_ip4:       192.168.4.2
+dest_ip4:      192.168.4.1
+xo update temp:3,diff:0,xo:0x3083c
+I (5750)-xf_main: mode=udp-client sip=192.168.4.2:5001,dip=192.168.4.1:5001,interval=1, time=10
+I (5754)-iperf: Socket created, sending to 192.168.4.1:5001
+
+        Interval Bandwidth
+xo update temp:4,diff:0,xo:0x3083c
+   0-   1 sec       44.05 Mbits/sec
+   1-   2 sec       40.38 Mbits/sec
+   2-   3 sec       34.30 Mbits/sec
+   3-   4 sec       34.48 Mbits/sec
+   4-   5 sec       37.54 Mbits/sec
+   5-   6 sec       33.38 Mbits/sec
+   6-   7 sec       33.49 Mbits/sec
+   7-   8 sec       34.25 Mbits/sec
+   8-   9 sec       35.19 Mbits/sec
+   9-  10 sec       40.80 Mbits/sec
+   0-  10 sec       36.79 Mbits/sec
+I (15983)-iperf: UDP Socket client is closed
+I (15986)-iperf: iperf done
+I (19121)-xf_main: mode=tcp-client sip=192.168.4.2:5001,dip=192.168.4.1:5001,interval=1, time=10
+I (19135)-iperf: Successfully connected
+
+        Interval Bandwidth
+   0-   1 sec       6.81 Mbits/sec
+   1-   2 sec       6.68 Mbits/sec
+   2-   3 sec       6.81 Mbits/sec
+   3-   4 sec       6.29 Mbits/sec
+   4-   5 sec       7.20 Mbits/sec
+   5-   6 sec       7.20 Mbits/sec
+   6-   7 sec       7.34 Mbits/sec
+   7-   8 sec       7.34 Mbits/sec
+   8-   9 sec       7.20 Mbits/sec
+   9-  10 sec       7.20 Mbits/sec
+   0-  10 sec       7.01 Mbits/sec
+I (29154)-iperf: TCP Socket client is closed.
+I (29154)-iperf: iperf done
+I (32221)-xf_main: mode=udp-server sip=192.168.4.2:5001,dip=192.168.4.1:5001,interval=1, time=10
+I (32226)-iperf: Socket created
+I (32229)-iperf: Socket bound, port 35091
+
+        Interval Bandwidth
+   0-   1 sec       22.42 Mbits/sec
+   1-   2 sec       23.03 Mbits/sec
+   2-   3 sec       18.59 Mbits/sec
+   3-   4 sec       21.83 Mbits/sec
+   4-   5 sec       20.08 Mbits/sec
+   5-   6 sec       20.85 Mbits/sec
+   6-   7 sec       20.29 Mbits/sec
+   7-   8 sec       21.68 Mbits/sec
+   8-   9 sec       21.77 Mbits/sec
+   9-  10 sec       21.36 Mbits/sec
+   0-  10 sec       21.19 Mbits/sec
+I (42313)-iperf: Udp socket server is closed.
+I (42317)-iperf: iperf done
+I (45332)-xf_main: mode=tcp-server sip=192.168.4.2:5001,dip=192.168.4.1:5001,interval=1, time=10
+I (45336)-iperf: Socket created
+I (45741)-iperf: accept: 192.168.4.1,64210
+
+
+        Interval Bandwidth
+   0-   1 sec       7.53 Mbits/sec
+   1-   2 sec       7.88 Mbits/sec
+   2-   3 sec       7.80 Mbits/sec
+   3-   4 sec       7.92 Mbits/sec
+   4-   5 sec       8.06 Mbits/sec
+   5-   6 sec       7.11 Mbits/sec
+   6-   7 sec       7.73 Mbits/sec
+   7-   8 sec       7.91 Mbits/sec
+   8-   9 sec       7.87 Mbits/sec
+   9-  10 sec       8.03 Mbits/sec
+   0-  10 sec       7.78 Mbits/sec
+I (55780)-iperf: TCP Socket server is closed.
+I (55783)-iperf: iperf done
+I (55802)-xf_main: test done!
+```

--- a/examples/protocols/iperf/station/main/XFKconfig
+++ b/examples/protocols/iperf/station/main/XFKconfig
@@ -1,0 +1,23 @@
+
+config EXAMPLE_IPERF_TIME
+    int "Set the iperf running time (unit: second)."
+    default 10
+
+config EXAMPLE_IPERF_AUTO_TEST
+    bool "iperf automatically switches roles and protocols for testing."
+    default y
+    help
+        iperf automatically switches roles and protocols for testing. 
+        If you select No, you need to manually select the role and protocol of iperf.
+
+if !EXAMPLE_IPERF_AUTO_TEST
+
+    config EXAMPLE_IPERF_SELECT_SERVER
+        bool "iperf selects the server. Otherwise, select the client."
+        default n
+
+    config EXAMPLE_IPERF_SELECT_UDP
+        bool "iperf Indicates the udp protocol. Otherwise, tcp is selected."
+        default y
+
+endif # !EXAMPLE_IPERF_AUTO_TEST

--- a/examples/protocols/iperf/station/main/xf_collect.py
+++ b/examples/protocols/iperf/station/main/xf_collect.py
@@ -1,0 +1,3 @@
+import xf_build
+
+xf_build.collect()

--- a/examples/protocols/iperf/station/main/xf_main.c
+++ b/examples/protocols/iperf/station/main/xf_main.c
@@ -1,0 +1,182 @@
+/**
+ * @file xf_main.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-06-06
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include "xfconfig.h"
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/inet.h"
+
+#include "xf_utils.h"
+#include "xf_wifi.h"
+#include "xf_netif.h"
+#include "xf_osal.h"
+#include "xf_sys.h"
+
+#include "xf_iperf.h"
+
+#include "ex_easy_wifi.h"
+
+/* ==================== [Defines] =========================================== */
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static void _example_thread(void *argument);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "xf_main";
+
+static xf_osal_thread_t s_thread_hdl = NULL;
+#define EX_THREAD_NAME          "ex_thread"
+#define EX_THREAD_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define EX_THREAD_STACK_SIZE    (1024 * 4)
+static const xf_osal_thread_attr_t s_thread_attr = {
+    .name       = EX_THREAD_NAME,
+    .priority   = EX_THREAD_PRIORITY,
+    .stack_size = EX_THREAD_STACK_SIZE,
+};
+
+#ifdef CONFIG_EXAMPLE_IPERF_AUTO_TEST
+static const uint32_t s_iperf_test_item[] = {
+    IPERF_FLAG_CLIENT | IPERF_FLAG_UDP,
+    IPERF_FLAG_CLIENT | IPERF_FLAG_TCP,
+    IPERF_FLAG_SERVER | IPERF_FLAG_UDP,
+    IPERF_FLAG_SERVER | IPERF_FLAG_TCP,
+};
+#endif /* CONFIG_EXAMPLE_IPERF_AUTO_TEST */
+
+/* ==================== [Macros] ============================================ */
+
+/* ==================== [Global Functions] ================================== */
+
+void xf_main(void)
+{
+    s_thread_hdl = xf_osal_thread_create(_example_thread, NULL, &s_thread_attr);
+    if (s_thread_hdl == NULL) {
+        XF_LOGE(TAG, "xf_osal_thread_create error");
+        return;
+    }
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static void _example_thread(void *argument)
+{
+    UNUSED(argument);
+
+    uint32_t test_idx = 0;
+
+    xf_ip4_addr_t dest_ip4 = {0};
+    xf_ip4_addr_t src_ip4 = {0};
+
+    ex_easy_wifi_sta();
+    src_ip4 = ex_easy_wifi_sta_get_onw_ip();
+    dest_ip4 = ex_easy_wifi_sta_get_gw_ip();
+
+    XF_LOGI(TAG, "\n"
+            "src_ip4:       " XF_IPSTR "\n"
+            "dest_ip4:      " XF_IPSTR,
+            XF_IP2STR(&src_ip4),
+            XF_IP2STR(&dest_ip4));
+
+    xf_sys_watchdog_disable();
+
+    for (test_idx = 0; test_idx < ARRAY_SIZE(s_iperf_test_item); ++test_idx) {
+        xf_osal_delay_ms(IPERF_SOCKET_RX_TIMEOUT_MS);
+        xf_iperf_stop();
+
+        xf_iperf_cfg_t cfg  = XF_IPERF_DEFAULT_CONFIG();
+        cfg.type            = IPERF_IP_TYPE_IPV4;
+        cfg.time            = CONFIG_EXAMPLE_IPERF_TIME;
+        cfg.destination_ip4 = dest_ip4.addr;
+        cfg.source_ip4      = src_ip4.addr;
+
+#ifdef CONFIG_EXAMPLE_IPERF_AUTO_TEST
+        if (s_iperf_test_item[test_idx] & IPERF_FLAG_CLIENT) {
+            /* 延迟一会，避免服务端还没建立 */
+            xf_osal_delay_ms(100);
+        }
+        cfg.flag = s_iperf_test_item[test_idx];
+#else
+#   if defined(CONFIG_EXAMPLE_IPERF_SELECT_SERVER)
+        cfg.flag |= IPERF_FLAG_SERVER;
+#   else
+        cfg.flag |= IPERF_FLAG_CLIENT;
+#   endif
+#   if defined(CONFIG_EXAMPLE_IPERF_SELECT_UDP)
+        cfg.flag |= IPERF_FLAG_UDP;
+#   else
+        cfg.flag |= IPERF_FLAG_TCP;
+#   endif
+#endif /* CONFIG_EXAMPLE_IPERF_AUTO_TEST */
+
+        XF_LOGI(TAG,
+                "mode=%s-%s sip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
+                "dip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
+                "interval=%" PRId32 ", time=%" PRId32 "",
+                cfg.flag & IPERF_FLAG_TCP ? "tcp" : "udp",
+                cfg.flag & IPERF_FLAG_SERVER ? "server" : "client",
+                cfg.source_ip4 & 0xFF, (cfg.source_ip4 >> 8) & 0xFF, (cfg.source_ip4 >> 16) & 0xFF,
+                (cfg.source_ip4 >> 24) & 0xFF, cfg.sport,
+                cfg.destination_ip4 & 0xFF, (cfg.destination_ip4 >> 8) & 0xFF,
+                (cfg.destination_ip4 >> 16) & 0xFF, (cfg.destination_ip4 >> 24) & 0xFF, cfg.dport,
+                cfg.interval, cfg.time);
+
+        xf_iperf_start(&cfg, NULL, NULL);
+
+        while (xf_iperf_is_running()) {
+            xf_osal_delay_ms(100);
+        }
+    } /* for */
+
+    XF_LOGI(TAG, "test done!");
+
+    xf_osal_thread_delete(NULL);
+}
+
+// /**
+//  * @brief iperf 回调函数。
+//  *
+//  * 这是 iperf 回调示例，如果不需要 iperf 内部报告，
+//  * 则需要修改 `xf_iperf_cfg_t.report_enabled = false;
+//  * 并使用该回调 `xf_iperf_start(&cfg, _xf_iperf_cb, NULL);`
+//  *
+//  * @param event_id iperf 事件 id.
+//  * @param hdl iperf 句柄。
+//  * @param user_args 用户数据。
+//  */
+// static void _xf_iperf_cb(
+//     xf_iperf_event_id_t event_id, xf_iperf_t hdl, void *user_args)
+// {
+//     UNUSED(user_args);
+//     switch (event_id) {
+//     case XF_IPERF_EVENT_START: {
+//         XF_LOGI(TAG, "%16s %s", "Interval", "Bandwidth");
+//     } break;
+//     case XF_IPERF_EVENT_REPORT: {
+//         XF_LOGI(TAG, "%4d-%4d sec       %.2f Mbits/sec",
+//                 hdl->curr_time, hdl->curr_time + hdl->cfg.interval,
+//                 hdl->actual_bandwidth);
+//     } break;
+//     case XF_IPERF_EVENT_END: {
+//         XF_LOGI(TAG, "%4d-%4d sec       %.2f Mbits/sec",
+//                 0, hdl->cfg.time, hdl->average_bandwidth);
+//     } break;
+//     default:
+//         break;
+//     }
+// }

--- a/examples/protocols/iperf/station/xf_project.py
+++ b/examples/protocols/iperf/station/xf_project.py
@@ -1,0 +1,11 @@
+import xf_build
+from xf_build import api
+from pathlib import Path
+
+example_components_path: Path = api.XF_ROOT / "examples" / "example_components"
+
+example_components = []
+example_components.append((example_components_path / "ex_easy_wifi").as_posix())
+
+xf_build.project_init(user_dirs=example_components)
+xf_build.program()

--- a/examples/protocols/iperf/station/xfconfig.defaults
+++ b/examples/protocols/iperf/station/xfconfig.defaults
@@ -1,0 +1,2 @@
+# Welcome to xfusion
+CONFIG_XF_HEAP_STATIC_SIZE=20480

--- a/examples/protocols/sockets/tcp_client/README.md
+++ b/examples/protocols/sockets/tcp_client/README.md
@@ -1,0 +1,159 @@
+# sockets:tcp_client - socket tcp 客户端通信示例
+
+## 支持情况
+
+1.  espressif
+
+    1.  esp32
+
+1.  nearlink
+
+    1.  ws63
+
+## 示例简述
+
+本示例演示 wifi 连接到 ap 后启动 socket tcp 客户端，之后与服务器(地址默认为 `gw`)通信.
+
+## 如何使用
+
+1.  所需的软件和硬件。
+
+    1.  外部软件包。
+
+        无。
+
+    1.  硬件。
+
+        片内支持 wifi 的芯片，如 esp32、ws63.
+
+1.  配置。
+
+    无特殊配置项。
+
+1.  构建和烧录步骤与要点。
+
+    无。
+
+## 运行现象
+
+本示例连接到 ap 获取到 ip 后后，创建 tcp 客户端(默认端口号为 `3333`)向 tcp 服务端发送 `This is a message from client.`，接收到数据后通过 log 输出，以此循环。
+
+## 常见问题
+
+无。
+
+## 示例平台差异
+
+此示例对以下目标无明显差异：
+
+1. esp32
+1. ws63
+
+## 运行日志
+
+以下是 esp32 的运行日志。
+
+```
+I (329)-ex_easy_wifi: STA has started.
+I (3312) wifi:new:<6,1>, old:<1,0>, ap:<255,255>, sta:<6,1>, prof:6
+I (3314) wifi:state: init -> auth (b0)
+I (3335) wifi:state: auth -> assoc (0)
+I (3355) wifi:state: assoc -> run (10)
+I (3376) wifi:connected with myssid, aid = 1, channel 6, 40U, bssid = 08:3a:f2:bf:26:e1
+I (3377) wifi:security: WPA2-PSK, phy: bgn, rssi: -12
+I (3381) wifi:pm start, type: 1
+
+I (3382) wifi:dp: 1, bi: 102400, li: 3, scale listen interval from 307200 us to 307200 us
+I (2843)-ex_easy_wifi: The STA is connected to the AP.
+I (2845)-ex_easy_wifi:
+ssid:      myssid
+mac:       08:3a:f2:bf:26:e1
+channel:   6
+authmode:  4
+I (3432) wifi:dp: 2, bi: 102400, li: 4, scale listen interval from 307200 us to 409600 us
+I (3432) wifi:AP's beacon interval = 102400 us, DTIM period = 2
+I (4394) esp_netif_handlers: sta ip: 192.168.4.2, mask: 255.255.255.0, gw: 192.168.4.1
+I (3845)-ex_easy_wifi:
+got ip:       192.168.4.2
+got gw:       192.168.4.1
+got netmask:  255.255.255.0
+I (4506) wifi:<ba-add>idx:0 (ifx:0, 08:3a:f2:bf:26:e1), tid:0, ssn:0, winSize:64
+I (3967)-sta: Successfully connected to 192.168.4.1:3333
+I (4970)-sta: sent     30 bytes: "This is a message from client."
+I (4978)-sta: Received 30 bytes: "This is a message from server."
+I (5981)-sta: sent     30 bytes: "This is a message from client."
+I (5990)-sta: Received 30 bytes: "This is a message from server."
+I (6993)-sta: sent     30 bytes: "This is a message from client."
+I (7004)-sta: Received 30 bytes: "This is a message from server."
+I (8007)-sta: sent     30 bytes: "This is a message from client."
+I (8020)-sta: Received 30 bytes: "This is a message from server."
+I (9022)-sta: sent     30 bytes: "This is a message from client."
+I (9037)-sta: Received 30 bytes: "This is a message from server."
+I (10040)-sta: sent     30 bytes: "This is a message from client."
+I (10058)-sta: Received 30 bytes: "This is a message from server."
+I (11061)-sta: sent     30 bytes: "This is a message from client."
+I (11077)-sta: Received 30 bytes: "This is a message from server."
+...
+```
+
+以下是 ws63 的运行日志。
+
+```I (225)-ex_easy_wifi: STA has started.
+Srv:2047: last scantime > 5s, trigger scan
+wifi_sta_connect_fill_scan_param:: Specifying an SSID for scanning
+drv_soc_ioctl ioctl_cmd->cmd=14.
+hmac_single_hal_device_scan_complete:vap[1] time[762] chan_cnt[13] chan_0[1] back[0] event[6] mode[0]
+Scan::vap[1] find bss_num[0] in regdomain, other bss_num[0]
+Srv:548:recive event = 1
+Srv:216:scan triggered by connect!
+Srv:1974: not found suitable SSID and auth type
+Srv:1974: not found suitable SSID and auth type
+xo update temp:3,diff:0,xo:0x3083c
+Srv:2047: last scantime > 5s, trigger scan
+wifi_sta_connect_fill_scan_param:: Specifying an SSID for scanning
+drv_soc_ioctl ioctl_cmd->cmd=14.
+hmac_single_hal_device_scan_complete:vap[1] time[762] chan_cnt[13] chan_0[1] back[0] event[6] mode[0]
+Scan::vap[1] find bss_num[1] in regdomain, other bss_num[0]
+Srv:548:recive event = 1
+Srv:216:scan triggered by connect!
+Srv:find ssid[myssid] auth type[3] pairwise[3] ft_flag[0]
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=16.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
+drv_soc_ioctl ioctl_cmd->cmd=1.
++NOTICE:CONNECTED
+drv_soc_ioctl ioctl_cmd->cmd=6.
+Srv:548:recive event = 2
+I (7415)-ex_easy_wifi: The STA is connected to the AP.
+I (7420)-ex_easy_wifi: 
+ssid:      myssid
+mac:       a4:00:73:c0:62:a6
+channel:   6
+authmode:  4
+I (8631)-ex_easy_wifi: 
+got ip:       192.168.4.2
+got gw:       192.168.4.1
+got netmask:  255.255.255.0
+I (9654)-sta: Successfully connected to 192.168.4.1:3333
+I (10651)-sta: sent     30 bytes: "This is a message from client."
+I (10674)-sta: Received 30 bytes: "This is a message from server."
+I (11672)-sta: sent     30 bytes: "This is a message from client."
+I (11678)-sta: Received 30 bytes: "This is a message from server."
+I (12682)-sta: sent     30 bytes: "This is a message from client."
+I (12704)-sta: Received 30 bytes: "This is a message from server."
+I (13702)-sta: sent     30 bytes: "This is a message from client."
+I (13718)-sta: Received 30 bytes: "This is a message from server."
+I (14712)-sta: sent     30 bytes: "This is a message from client."
+I (14721)-sta: Received 30 bytes: "This is a message from server."
+I (15722)-sta: sent     30 bytes: "This is a message from client."
+...
+```

--- a/examples/protocols/sockets/tcp_client/main/XFKconfig
+++ b/examples/protocols/sockets/tcp_client/main/XFKconfig
@@ -1,0 +1,4 @@
+
+config EXAMPLE_PORT
+    int "socket port number."
+    default 3333

--- a/examples/protocols/sockets/tcp_client/main/xf_collect.py
+++ b/examples/protocols/sockets/tcp_client/main/xf_collect.py
@@ -1,0 +1,3 @@
+import xf_build
+
+xf_build.collect()

--- a/examples/protocols/sockets/tcp_client/main/xf_main.c
+++ b/examples/protocols/sockets/tcp_client/main/xf_main.c
@@ -1,0 +1,144 @@
+/**
+ * @file xf_main.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-06-06
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/netdb.h"
+#include "lwip/inet.h"
+
+#include "xf_utils.h"
+#include "xf_wifi.h"
+#include "xf_netif.h"
+#include "xf_osal.h"
+
+#include "ex_easy_wifi.h"
+
+/* ==================== [Defines] =========================================== */
+
+#define PORT                CONFIG_EXAMPLE_PORT
+#define EXAMPLE_DELAY_MS    1000
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static void _example_thread(void *argument);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "sta";
+static const char *payload = "This is a message from client.";
+
+static xf_osal_thread_t s_thread_hdl = NULL;
+#define EX_THREAD_NAME          "ex_thread"
+#define EX_THREAD_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define EX_THREAD_STACK_SIZE    (1024 * 4)
+static const xf_osal_thread_attr_t s_thread_attr = {
+    .name       = EX_THREAD_NAME,
+    .priority   = EX_THREAD_PRIORITY,
+    .stack_size = EX_THREAD_STACK_SIZE,
+};
+
+/* ==================== [Macros] ============================================ */
+
+/* ==================== [Global Functions] ================================== */
+
+void xf_main(void)
+{
+    s_thread_hdl = xf_osal_thread_create(_example_thread, NULL, &s_thread_attr);
+    if (s_thread_hdl == NULL) {
+        XF_LOGE(TAG, "xf_osal_thread_create error");
+        return;
+    }
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static void _example_thread(void *argument)
+{
+    UNUSED(argument);
+
+    ex_easy_wifi_sta();
+
+    /* 默认网关为主机 */
+    xf_ip4_addr_t host_ip4 = {0};
+    host_ip4 = ex_easy_wifi_sta_get_gw_ip();
+
+    int err = 0;
+    char rx_buffer[128];
+    int addr_family = 0;
+    int ip_protocol = 0;
+    int sockfd = 0;
+
+    struct sockaddr_in dest_addr = {0};
+    struct timeval timeout = {0};
+
+    dest_addr.sin_addr.s_addr   = host_ip4.addr;
+    dest_addr.sin_family        = AF_INET;
+    dest_addr.sin_port          = htons(PORT);
+    addr_family                 = AF_INET;
+    ip_protocol                 = IPPROTO_IP;
+
+    sockfd = socket(addr_family, SOCK_STREAM, ip_protocol);
+    if (sockfd < 0) {
+        XF_LOGE(TAG, "Unable to create socket: errno %d", errno);
+        goto l_err;
+    }
+
+    err = connect(sockfd, (struct sockaddr *)&dest_addr, sizeof(struct sockaddr_in));
+    if (err != 0) {
+        XF_LOGE(TAG, "Socket unable to connect: errno %d", errno);
+        goto l_err;
+    }
+
+    XF_LOGI(TAG, "Successfully connected to " XF_IPSTR ":%d",
+            XF_IP2STR(&host_ip4), PORT);
+
+    /* 设置超时时间 */
+    timeout.tv_sec = 10;
+    timeout.tv_usec = 0;
+    setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+    for (;;) {
+        xf_osal_delay_ms(EXAMPLE_DELAY_MS);
+
+        /* 发送 */
+        int payload_len = strlen(payload);
+        err = send(sockfd, payload, payload_len, 0);
+        if (err < 0) {
+            XF_LOGE(TAG, "Error occurred during sending: errno %d", errno);
+            continue;
+        }
+        XF_LOGI(TAG, "sent     %d bytes: \"%s\"", payload_len, payload);
+
+        /* 接收 */
+        int len = recv(sockfd, rx_buffer, sizeof(rx_buffer) - 1, 0);
+        if (len < 0) {
+            XF_LOGE(TAG, "recvfrom failed: errno %d", errno);
+            continue;
+        }
+
+        /* 收到数据 */
+        rx_buffer[len] = 0;
+        XF_LOGI(TAG, "Received %d bytes: \"%s\"", len, rx_buffer);
+    }
+
+l_err:;
+    if (sockfd != -1) {
+        XF_LOGE(TAG, "Shutting down socket...");
+        shutdown(sockfd, 0);
+        closesocket(sockfd);
+    }
+    xf_osal_thread_delete(NULL);
+}

--- a/examples/protocols/sockets/tcp_client/xf_project.py
+++ b/examples/protocols/sockets/tcp_client/xf_project.py
@@ -1,0 +1,11 @@
+import xf_build
+from xf_build import api
+from pathlib import Path
+
+example_components_path: Path = api.XF_ROOT / "examples" / "example_components"
+
+example_components = []
+example_components.append((example_components_path / "ex_easy_wifi").as_posix())
+
+xf_build.project_init(user_dirs=example_components)
+xf_build.program()

--- a/examples/protocols/sockets/tcp_server/README.md
+++ b/examples/protocols/sockets/tcp_server/README.md
@@ -1,0 +1,120 @@
+# sockets:tcp_server - wifi socket tcp 服务端通信示例
+
+## 支持情况
+
+1.  espressif
+
+    1.  esp32
+
+1.  nearlink
+
+    1.  ws63
+
+## 示例简述
+
+本示例演示启动 wifi ap 后启动 socket tcp 服务端并监听客户端连接，之后与客户端相互收发数据.
+
+## 如何使用
+
+1.  所需的软件和硬件。
+
+    1.  外部软件包。
+
+        无。
+
+    1.  硬件。
+
+        片内支持 wifi 的芯片，如 esp32、ws63.
+
+1.  配置。
+
+    无特殊配置项。
+
+1.  构建和烧录步骤与要点。
+
+    无。
+
+## 运行现象
+
+本示例启动 ap 等到 sta 连接后，创建 tcp 服务端(默认端口号为 `3333`)接收任意地址的数据，接收到数据后通过 log 输出，之后向来源发送 `This is a message from server.`，以此循环。
+
+## 常见问题
+
+无。
+
+## 示例平台差异
+
+此示例对以下目标无明显差异：
+
+1. esp32
+1. ws63
+
+## 运行日志
+
+以下是 esp32 的运行日志。
+
+```I (281)-ex_easy_wifi: AP has started.
+I (5870) wifi:new:<6,1>, old:<6,1>, ap:<6,1>, sta:<255,255>, prof:6
+I (5871) wifi:station: aa:bb:cc:dd:ee:ff join, AID=1, bgn, 40U
+I (5349)-ex_easy_wifi: station aa:bb:cc:dd:ee:ff join
+I (5936) esp_netif_lwip: DHCP server assigned IP to a client, IP is: 192.168.4.2
+I (5385)-ex_easy_wifi: Assign ip 192.168.4.2 to site aa:bb:cc:dd:ee:ff
+I (5477)-ap: Socket created
+I (5478)-ap: Socket bound, port 3333
+I (5479)-ap: Socket listening
+I (7032) wifi:<ba-add>idx:2 (ifx:1, aa:bb:cc:dd:ee:ff), tid:0, ssn:0, winSize:64
+I (7495)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (7498)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+I (8506)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (8508)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+I (9518)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (9520)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+I (10534)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (10536)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+I (11555)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (11557)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+I (12576)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (12578)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+...
+```
+
+以下是 ws63 的运行日志。
+
+```
+I (232)-ex_easy_wifi: AP has started.
+xo update temp:3,diff:0,xo:0x30b3c
+drv_soc_ioctl ioctl_cmd->cmd=2.
+
+drv_soc_ioctl ioctl_cmd->cmd=2.
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
++NOTICE:STA CONNECTED
+drv_soc_ioctl ioctl_cmd->cmd=6.
+Srv:548:recive event = 11
+Srv:2781:sta_num[1]!!
+I (6493)-ex_easy_wifi: station aa:bb:cc:dd:ee:ff join
+I (6730)-ex_easy_wifi: Assign ip 192.168.4.2 to site aa:bb:cc:dd:ee:ff
+I (6740)-ap: Socket created
+I (6740)-ap: Socket bound, port 3333
+I (6742)-ap: Socket listening
+I (9716)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (9721)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+I (10736)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (10740)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+I (11755)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (11759)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+xo update temp:4,diff:0,xo:0x30b3c
+I (12769)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (12773)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+I (13777)-ap: Received 30 bytes from 192.168.4.2: "This is a message from client."
+I (13782)-ap: send     30 bytes to   192.168.4.2: "This is a message from server."
+...
+```

--- a/examples/protocols/sockets/tcp_server/main/XFKconfig
+++ b/examples/protocols/sockets/tcp_server/main/XFKconfig
@@ -1,0 +1,23 @@
+
+config EXAMPLE_PORT
+    int "socket port number."
+    default 3333
+
+config EXAMPLE_KEEPALIVE_IDLE
+    int "TCP keep-alive idle time(s)"
+    default 5
+    help
+        Keep-alive idle time. In idle time without receiving any data from peer, will send keep-alive probe packet
+
+config EXAMPLE_KEEPALIVE_INTERVAL
+    int "TCP keep-alive interval time(s)"
+    default 5
+    help
+        Keep-alive probe packet interval time.
+
+config EXAMPLE_KEEPALIVE_COUNT
+    int "TCP keep-alive packet retry send counts"
+    default 3
+    help
+        Keep-alive probe packet retry count.
+    

--- a/examples/protocols/sockets/tcp_server/main/xf_collect.py
+++ b/examples/protocols/sockets/tcp_server/main/xf_collect.py
@@ -1,0 +1,3 @@
+import xf_build
+
+xf_build.collect()

--- a/examples/protocols/sockets/tcp_server/main/xf_main.c
+++ b/examples/protocols/sockets/tcp_server/main/xf_main.c
@@ -1,0 +1,186 @@
+/**
+ * @file xf_main.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-06-06
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/netdb.h"
+#include "lwip/inet.h"
+
+#include "xf_utils.h"
+#include "xf_wifi.h"
+#include "xf_netif.h"
+#include "xf_osal.h"
+#include "xf_sys.h"
+
+#include "ex_easy_wifi.h"
+
+/* ==================== [Defines] =========================================== */
+
+#define PORT                CONFIG_EXAMPLE_PORT
+#define KEEPALIVE_IDLE      CONFIG_EXAMPLE_KEEPALIVE_IDLE
+#define KEEPALIVE_INTERVAL  CONFIG_EXAMPLE_KEEPALIVE_INTERVAL
+#define KEEPALIVE_COUNT     CONFIG_EXAMPLE_KEEPALIVE_COUNT
+#define EXAMPLE_DELAY_MS    1000
+#define CLIENT_IP_ADDR      INADDR_ANY
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static void _example_thread(void *argument);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "ap";
+static const char *payload = "This is a message from server.";
+
+static xf_osal_thread_t s_thread_hdl = NULL;
+#define EX_THREAD_NAME          "ex_thread"
+#define EX_THREAD_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define EX_THREAD_STACK_SIZE    (1024 * 4)
+static const xf_osal_thread_attr_t s_thread_attr = {
+    .name       = EX_THREAD_NAME,
+    .priority   = EX_THREAD_PRIORITY,
+    .stack_size = EX_THREAD_STACK_SIZE,
+};
+
+/* ==================== [Macros] ============================================ */
+
+/* ==================== [Global Functions] ================================== */
+
+void xf_main(void)
+{
+    s_thread_hdl = xf_osal_thread_create(_example_thread, NULL, &s_thread_attr);
+    if (s_thread_hdl == NULL) {
+        XF_LOGE(TAG, "xf_osal_thread_create error");
+        return;
+    }
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static void _example_thread(void *argument)
+{
+    UNUSED(argument);
+
+    ex_easy_wifi_ap();
+
+    int err = 0;
+    char rx_buffer[128];
+    int addr_family = 0;
+    int ip_protocol = 0;
+    int sockfd_listen = 0;
+    int sockfd_conn = 0;
+    int keepAlive = 1;
+    int keepIdle = KEEPALIVE_IDLE;
+    int keepInterval = KEEPALIVE_INTERVAL;
+    int keepCount = KEEPALIVE_COUNT;
+    xf_ip4_addr_t src_ip4;
+
+    struct sockaddr_in dest_addr = {0};
+    struct sockaddr_in source_addr = {0};
+    struct timeval timeout = {0};
+
+    dest_addr.sin_addr.s_addr   = htonl(CLIENT_IP_ADDR);
+    dest_addr.sin_family        = AF_INET;
+    dest_addr.sin_port          = htons(PORT);
+    addr_family                 = AF_INET;
+    ip_protocol                 = IPPROTO_IP;
+
+    sockfd_listen = socket(addr_family, SOCK_STREAM, ip_protocol);
+    if (sockfd_listen < 0) {
+        XF_LOGE(TAG, "Unable to create socket: errno %d", errno);
+        goto l_err;
+    }
+    XF_LOGI(TAG, "Socket created");
+
+    /* 绑定端口号 */
+    err = bind(sockfd_listen, (struct sockaddr *)&dest_addr, sizeof(dest_addr));
+    if (err < 0) {
+        XF_LOGE(TAG, "Socket unable to bind: errno %d", errno);
+        goto l_err;
+    }
+    XF_LOGI(TAG, "Socket bound, port %d", PORT);
+
+    /* 监听 */
+    err = listen(sockfd_listen, 1);
+    if (err != 0) {
+        XF_LOGE(TAG, "Error occurred during listen: errno %d", errno);
+        goto l_err;
+    }
+
+    XF_LOGI(TAG, "Socket listening");
+
+    socklen_t addr_len = sizeof(source_addr);
+    sockfd_conn = accept(sockfd_listen, (struct sockaddr *)&source_addr, &addr_len);
+    if (sockfd_conn < 0) {
+        XF_LOGE(TAG, "Unable to accept connection: errno %d", errno);
+        goto l_err;
+    }
+
+    timeout.tv_sec = 10;
+    timeout.tv_usec = 0;
+    setsockopt(sockfd_conn, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+    /* 设置 tcp keepalive 选项 */
+    setsockopt(sockfd_conn, SOL_SOCKET, SO_KEEPALIVE, &keepAlive, sizeof(int));
+    setsockopt(sockfd_conn, IPPROTO_TCP, TCP_KEEPIDLE, &keepIdle, sizeof(int));
+    setsockopt(sockfd_conn, IPPROTO_TCP, TCP_KEEPINTVL, &keepInterval, sizeof(int));
+    setsockopt(sockfd_conn, IPPROTO_TCP, TCP_KEEPCNT, &keepCount, sizeof(int));
+
+    for (;;) {
+        socklen_t socklen = sizeof(source_addr);
+        int len = recvfrom(sockfd_conn,
+                           rx_buffer, sizeof(rx_buffer) - 1, 0,
+                           (struct sockaddr *)&source_addr, &socklen);
+        if (len < 0) {
+            XF_LOGE(TAG, "recvfrom failed: errno %d", errno);
+            continue;
+        } else if (len == 0) {
+            XF_LOGW(TAG, "Connection closed");
+        }
+
+        rx_buffer[len] = 0;
+
+        src_ip4.addr = source_addr.sin_addr.s_addr;
+        XF_LOGI(TAG, "Received %d bytes from " XF_IPSTR ": \"%s\"",
+                len, XF_IP2STR(&src_ip4), rx_buffer);
+
+        /* 发送 */
+        int payload_len = strlen(payload);
+        err = sendto(sockfd_conn,
+                     payload, payload_len, 0,
+                     (struct sockaddr *)&source_addr, sizeof(source_addr));
+        if (err < 0) {
+            XF_LOGE(TAG, "Error occurred during sending: errno %d", errno);
+            break;
+        }
+        XF_LOGI(TAG, "send     %d bytes to   " XF_IPSTR ": \"%s\"",
+                payload_len, XF_IP2STR(&src_ip4), payload);
+
+        xf_osal_delay_ms(EXAMPLE_DELAY_MS);
+    }
+
+l_err:;
+    if (sockfd_conn != -1) {
+        shutdown(sockfd_conn, 0);
+        closesocket(sockfd_conn);
+    }
+    if (sockfd_listen != -1) {
+        XF_LOGE(TAG, "Shutting down socket...");
+        shutdown(sockfd_listen, 0);
+        closesocket(sockfd_listen);
+    }
+    xf_osal_thread_delete(NULL);
+}

--- a/examples/protocols/sockets/tcp_server/xf_project.py
+++ b/examples/protocols/sockets/tcp_server/xf_project.py
@@ -1,0 +1,11 @@
+import xf_build
+from xf_build import api
+from pathlib import Path
+
+example_components_path: Path = api.XF_ROOT / "examples" / "example_components"
+
+example_components = []
+example_components.append((example_components_path / "ex_easy_wifi").as_posix())
+
+xf_build.project_init(user_dirs=example_components)
+xf_build.program()

--- a/examples/protocols/sockets/udp_client/README.md
+++ b/examples/protocols/sockets/udp_client/README.md
@@ -1,0 +1,153 @@
+# sockets:udp_client - wifi socket udp 客户端通信示例
+
+## 支持情况
+
+1.  espressif
+
+    1.  esp32
+
+1.  nearlink
+
+    1.  ws63
+
+## 示例简述
+
+本示例演示 wifi 连接到 ap 后启动 socket udp 客户端，之后与服务器(地址默认为 `gw`)通信.
+
+## 如何使用
+
+1.  所需的软件和硬件。
+
+    1.  外部软件包。
+
+        无。
+
+    1.  硬件。
+
+        片内支持 wifi 的芯片，如 esp32、ws63.
+
+1.  配置。
+
+    无特殊配置项。
+
+1.  构建和烧录步骤与要点。
+
+    无。
+
+## 运行现象
+
+本示例连接到 ap 获取到 ip 后后，创建 udp 客户端(默认端口号为 `3333`)向 udp 服务端发送 `This is a message from client.`，接收到数据后通过 log 输出，以此循环。
+
+## 常见问题
+
+无。
+
+## 示例平台差异
+
+此示例对以下目标无明显差异：
+
+1. esp32
+1. ws63
+
+## 运行日志
+
+以下是 esp32 的运行日志。
+
+```
+I (808)-ex_easy_wifi: STA has started.
+E (1822) wifi:sta is connecting, return error
+E (2832) wifi:sta is connecting, return error
+E (4854) wifi:sta is connecting, return error
+E (5864) wifi:sta is connecting, return error
+E (7886) wifi:sta is connecting, return error
+E (8896) wifi:sta is connecting, return error
+E (10918) wifi:sta is connecting, return error
+E (11928) wifi:sta is connecting, return error
+I (12319) wifi:new:<6,1>, old:<1,0>, ap:<255,255>, sta:<6,1>, prof:6
+I (12320) wifi:state: init -> auth (b0)
+I (12333) wifi:state: auth -> assoc (0)
+I (12355) wifi:state: assoc -> run (10)
+I (12377) wifi:connected with myssid, aid = 1, channel 6, 40U, bssid = 08:3a:f2:bf:1a:39
+I (12378) wifi:security: WPA2-PSK, phy: bgn, rssi: -17
+I (12381) wifi:pm start, type: 0
+
+I (12382) wifi:dp: 1, bi: 102400, li: 3, scale listen interval from 307200 us to 307200 us
+I (12393)-ex_easy_wifi: The STA is connected to the AP.
+I (12396)-ex_easy_wifi:
+ssid:      myssid
+mac:       08:3a:f2:bf:1a:39
+channel:   6
+authmode:  4
+I (12411) wifi:dp: 2, bi: 102400, li: 4, scale listen interval from 307200 us to 409600 us
+I (12414) wifi:AP's beacon interval = 102400 us, DTIM period = 2
+I (13392) esp_netif_handlers: sta ip: 192.168.4.2, mask: 255.255.255.0, gw: 192.168.4.1
+I (13394)-ex_easy_wifi:
+got ip:       192.168.4.2
+got gw:       192.168.4.1
+got netmask:  255.255.255.0
+I (13409)-sta: Socket created, sending to 192.168.4.1:3333
+I (13411)-sta: Message sent: "This is a message from client.".
+I (13417) wifi:<ba-add>idx:0 (ifx:0, 08:3a:f2:bf:1a:39), tid:0, ssn:0, winSize:64
+I (13441)-sta: Received 26 bytes from 192.168.4.1:
+I (13441)-sta: This is a message from server.
+I (13543)-sta: Message sent: "This is a message from client.".
+I (13546)-sta: Received 26 bytes from 192.168.4.1:
+I (13546)-sta: This is a message from server.
+I (13650)-sta: Message sent: "This is a message from client.".
+I (13656)-sta: Received 26 bytes from 192.168.4.1:
+I (13656)-sta: This is a message from server.
+I (13758)-sta: Message sent: "This is a message from client.".
+I (13771)-sta: Received 26 bytes from 192.168.4.1:
+I (13771)-sta: This is a message from server.
+...
+```
+
+以下是 ws63 的运行日志。
+
+```
+I (259)-ex_easy_wifi: STA has started.
+Srv:2047: last scantime > 5s, trigger scan
+wifi_sta_connect_fill_scan_param:: Specifying an SSID for scanning
+drv_soc_ioctl ioctl_cmd->cmd=14.
+hmac_single_hal_device_scan_complete:vap[1] time[762] chan_cnt[13] chan_0[1] back[0] event[6] mode[0]
+Scan::vap[1] find bss_num[1] in regdomain, other bss_num[0]
+Srv:548:recive event = 1
+Srv:216:scan triggered by connect!
+Srv:find ssid[myssid] auth type[3] pairwise[3] ft_flag[0]
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=16.
+drv_soc_ioctl ioctl_cmd->cmd=47.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
+drv_soc_ioctl ioctl_cmd->cmd=1.
++NOTICE:CONNECTED
+drv_soc_ioctl ioctl_cmd->cmd=6.
+Srv:548:recive event = 2
+I (1241)-ex_easy_wifi: The STA is connected to the AP.
+I (1245)-ex_easy_wifi:
+ssid:      myssid
+mac:       d2:00:73:71:2a:f7
+channel:   6
+authmode:  4
+I (2631)-ex_easy_wifi:
+got ip:       192.168.4.2
+got gw:       192.168.4.1
+got netmask:  255.255.255.0
+I (2680)-sta: Socket created, sending to 192.168.4.1:3333
+I (2682)-sta: Message sent: "This is a message from client.".
+I (2709)-sta: Received 26 bytes from 192.168.4.1:
+I (2709)-sta: This is a message from server.
+I (2811)-sta: Message sent: "This is a message from client.".
+I (2818)-sta: Received 26 bytes from 192.168.4.1:
+I (2819)-sta: This is a message from server.
+I (2921)-sta: Message sent: "This is a message from client.".
+...
+```

--- a/examples/protocols/sockets/udp_client/main/XFKconfig
+++ b/examples/protocols/sockets/udp_client/main/XFKconfig
@@ -1,0 +1,4 @@
+
+config EXAMPLE_PORT
+    int "socket port number."
+    default 3333

--- a/examples/protocols/sockets/udp_client/main/xf_collect.py
+++ b/examples/protocols/sockets/udp_client/main/xf_collect.py
@@ -1,0 +1,3 @@
+import xf_build
+
+xf_build.collect()

--- a/examples/protocols/sockets/udp_client/main/xf_main.c
+++ b/examples/protocols/sockets/udp_client/main/xf_main.c
@@ -1,0 +1,144 @@
+/**
+ * @file xf_main.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-06-06
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/netdb.h"
+#include "lwip/inet.h"
+
+#include "xf_utils.h"
+#include "xf_wifi.h"
+#include "xf_netif.h"
+#include "xf_osal.h"
+
+#include "ex_easy_wifi.h"
+
+/* ==================== [Defines] =========================================== */
+
+#define PORT                CONFIG_EXAMPLE_PORT
+#define EXAMPLE_DELAY_MS    1000
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static void _example_thread(void *argument);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "sta";
+static const char *payload = "This is a message from client.";
+
+static xf_osal_thread_t s_thread_hdl = NULL;
+#define EX_THREAD_NAME          "ex_thread"
+#define EX_THREAD_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define EX_THREAD_STACK_SIZE    (1024 * 4)
+static const xf_osal_thread_attr_t s_thread_attr = {
+    .name       = EX_THREAD_NAME,
+    .priority   = EX_THREAD_PRIORITY,
+    .stack_size = EX_THREAD_STACK_SIZE,
+};
+
+/* ==================== [Macros] ============================================ */
+
+/* ==================== [Global Functions] ================================== */
+
+void xf_main(void)
+{
+    s_thread_hdl = xf_osal_thread_create(_example_thread, NULL, &s_thread_attr);
+    if (s_thread_hdl == NULL) {
+        XF_LOGE(TAG, "xf_osal_thread_create error");
+        return;
+    }
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static void _example_thread(void *argument)
+{
+    UNUSED(argument);
+
+    ex_easy_wifi_sta();
+
+    /* 默认网关为主机 */
+    xf_ip4_addr_t host_ip4 = {0};
+    host_ip4 = ex_easy_wifi_sta_get_gw_ip();
+
+    char rx_buffer[128];
+    int addr_family = 0;
+    int ip_protocol = 0;
+    int sockfd = 0;
+
+    struct sockaddr_in dest_addr = {0};
+    struct sockaddr_in source_addr = {0};
+    struct timeval timeout = {0};
+
+    dest_addr.sin_addr.s_addr   = host_ip4.addr;
+    dest_addr.sin_family        = AF_INET;
+    dest_addr.sin_port          = htons(PORT);
+    addr_family                 = AF_INET;
+    ip_protocol                 = IPPROTO_IP;
+
+    sockfd = socket(addr_family, SOCK_DGRAM, ip_protocol);
+    if (sockfd < 0) {
+        XF_LOGE(TAG, "Unable to create socket: errno %d", errno);
+        goto l_err;
+    }
+
+    /* 设置超时时间 */
+    timeout.tv_sec = 10;
+    timeout.tv_usec = 0;
+    setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+    XF_LOGI(TAG, "Socket created, sending to " XF_IPSTR ":%d",
+            XF_IP2STR(&host_ip4), PORT);
+
+    for (;;) {
+        xf_osal_delay_ms(EXAMPLE_DELAY_MS);
+
+        /* 发送 */
+        int err = sendto(sockfd,
+                         payload, strlen(payload), 0,
+                         (struct sockaddr *)&dest_addr, sizeof(dest_addr));
+        if (err < 0) {
+            XF_LOGE(TAG, "Error occurred during sending: errno %d", errno);
+            continue;
+        }
+        XF_LOGI(TAG, "Message sent: \"%s\".", payload);
+
+        /* 接收 */
+        socklen_t socklen = sizeof(source_addr);
+        int len = recvfrom(sockfd,
+                           rx_buffer, sizeof(rx_buffer) - 1, 0,
+                           (struct sockaddr *)&source_addr, &socklen);
+        if (len < 0) {
+            XF_LOGE(TAG, "recvfrom failed: errno %d", errno);
+            continue;
+        }
+
+        /* 收到数据 */
+        rx_buffer[len] = 0;
+        XF_LOGI(TAG, "Received %d bytes from " XF_IPSTR ":",
+                len, XF_IP2STR(&host_ip4));
+        XF_LOGI(TAG, "%s", rx_buffer);
+    }
+
+l_err:;
+    if (sockfd != -1) {
+        XF_LOGE(TAG, "Shutting down socket...");
+        shutdown(sockfd, 0);
+        closesocket(sockfd);
+    }
+    xf_osal_thread_delete(NULL);
+}

--- a/examples/protocols/sockets/udp_client/xf_project.py
+++ b/examples/protocols/sockets/udp_client/xf_project.py
@@ -1,0 +1,11 @@
+import xf_build
+from xf_build import api
+from pathlib import Path
+
+example_components_path: Path = api.XF_ROOT / "examples" / "example_components"
+
+example_components = []
+example_components.append((example_components_path / "ex_easy_wifi").as_posix())
+
+xf_build.project_init(user_dirs=example_components)
+xf_build.program()

--- a/examples/protocols/sockets/udp_server/README.md
+++ b/examples/protocols/sockets/udp_server/README.md
@@ -1,0 +1,112 @@
+# sockets:udp_server - wifi socket udp 服务端通信示例
+
+## 支持情况
+
+1.  espressif
+
+    1.  esp32
+
+1.  nearlink
+
+    1.  ws63
+
+## 示例简述
+
+本示例演示启动 wifi ap 后启动 socket udp 服务端，之后与客户端通信.
+
+## 如何使用
+
+1.  所需的软件和硬件。
+
+    1.  外部软件包。
+
+        无。
+
+    1.  硬件。
+
+        片内支持 wifi 的芯片，如 esp32、ws63.
+
+1.  配置。
+
+    无特殊配置项。
+
+1.  构建和烧录步骤与要点。
+
+    无。
+
+## 运行现象
+
+本示例启动 ap 等到 sta 连接后，创建 udp 服务端(默认端口号为 `3333`)接收任意地址的数据，接收到数据后通过 log 输出，之后向来源发送 `This is a message from server.`，以此循环。
+
+## 常见问题
+
+无。
+
+## 示例平台差异
+
+此示例对以下目标无明显差异：
+
+1. esp32
+1. ws63
+
+## 运行日志
+
+以下是 esp32 的运行日志。
+
+```
+I (828)-ex_easy_wifi: AP has started.
+I (5275) wifi:new:<6,1>, old:<6,1>, ap:<6,1>, sta:<255,255>, prof:6
+I (5276) wifi:station: aa:bb:cc:dd:ee:ff join, AID=1, bgn, 40U
+I (5310)-ex_easy_wifi: station aa:bb:cc:dd:ee:ff join
+I (5347) esp_netif_lwip: DHCP server assigned IP to a client, IP is: 192.168.4.2
+I (5348)-ex_easy_wifi: Assign ip 192.168.4.2 to site aa:bb:cc:dd:ee:ff
+I (5431)-ap: Socket created
+I (5432)-ap: Socket bound, port 3333
+I (5432)-ap: Waiting for data.
+I (6363)-ap: Received 27 bytes from 192.168.4.2:
+I (6363)-ap: This is a message from client.
+I (6364) wifi:<ba-add>idx:2 (ifx:1, aa:bb:cc:dd:ee:ff), tid:0, ssn:0, winSize:64
+I (6470)-ap: Waiting for data.
+I (6477)-ap: Received 27 bytes from 192.168.4.2:
+I (6477)-ap: This is a message from client.
+I (6578)-ap: Waiting for data.
+I (6587)-ap: Received 27 bytes from 192.168.4.2:
+I (6588)-ap: This is a message from client.
+I (6688)-ap: Waiting for data.
+I (6700)-ap: Received 27 bytes from 192.168.4.2:
+I (6700)-ap: This is a message from client.
+...
+```
+
+以下是 ws63 的运行日志。
+
+```
+I (281)-ex_easy_wifi: AP has started.
+drv_soc_ioctl ioctl_cmd->cmd=2.
+
+drv_soc_ioctl ioctl_cmd->cmd=2.
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=5.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+drv_soc_ioctl ioctl_cmd->cmd=6.
+
+drv_soc_ioctl ioctl_cmd->cmd=1.
+drv_soc_ioctl ioctl_cmd->cmd=3.
++NOTICE:STA CONNECTED
+drv_soc_ioctl ioctl_cmd->cmd=6.
+Srv:548:recive event = 11
+Srv:2781:sta_num[1]!!
+I (1199)-ex_easy_wifi: station e2:00:73:95:66:27 join
+I (1619)-ex_easy_wifi: Assign ip 192.168.4.2 to site e2:00:73:95:66:27
+I (1699)-ap: Socket created
+I (1700)-ap: Socket bound, port 3333
+I (1701)-ap: Waiting for data.
+I (2643)-ap: Received 27 bytes from 192.168.4.2:
+I (2643)-ap: This is a message from client.
+I (2739)-ap: Waiting for data.
+I (2758)-ap: Received 27 bytes from 192.168.4.2:
+...
+```

--- a/examples/protocols/sockets/udp_server/main/XFKconfig
+++ b/examples/protocols/sockets/udp_server/main/XFKconfig
@@ -1,0 +1,4 @@
+
+config EXAMPLE_PORT
+    int "socket port number."
+    default 3333

--- a/examples/protocols/sockets/udp_server/main/xf_collect.py
+++ b/examples/protocols/sockets/udp_server/main/xf_collect.py
@@ -1,0 +1,3 @@
+import xf_build
+
+xf_build.collect()

--- a/examples/protocols/sockets/udp_server/main/xf_main.c
+++ b/examples/protocols/sockets/udp_server/main/xf_main.c
@@ -1,0 +1,150 @@
+/**
+ * @file xf_main.c
+ * @author catcatBlue (catcatblue@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2024-06-06
+ *
+ * Copyright (c) 2024, CorAL. All rights reserved.
+ *
+ */
+
+/* ==================== [Includes] ========================================== */
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include "lwip/netdb.h"
+#include "lwip/inet.h"
+
+#include "xf_utils.h"
+#include "xf_wifi.h"
+#include "xf_netif.h"
+#include "xf_osal.h"
+
+#include "ex_easy_wifi.h"
+
+/* ==================== [Defines] =========================================== */
+
+#define PORT                CONFIG_EXAMPLE_PORT
+#define EXAMPLE_DELAY_MS    100
+#define CLIENT_IP_ADDR      INADDR_ANY
+
+/* ==================== [Typedefs] ========================================== */
+
+/* ==================== [Static Prototypes] ================================= */
+
+static void _example_thread(void *argument);
+
+/* ==================== [Static Variables] ================================== */
+
+static const char *TAG = "ap";
+static const char *payload = "This is a message from server.";
+
+static xf_osal_thread_t s_thread_hdl = NULL;
+#define EX_THREAD_NAME          "ex_thread"
+#define EX_THREAD_PRIORITY      XF_OSAL_PRIORITY_NORMOL
+#define EX_THREAD_STACK_SIZE    (1024 * 4)
+static const xf_osal_thread_attr_t s_thread_attr = {
+    .name       = EX_THREAD_NAME,
+    .priority   = EX_THREAD_PRIORITY,
+    .stack_size = EX_THREAD_STACK_SIZE,
+};
+
+/* ==================== [Macros] ============================================ */
+
+/* ==================== [Global Functions] ================================== */
+
+void xf_main(void)
+{
+    s_thread_hdl = xf_osal_thread_create(_example_thread, NULL, &s_thread_attr);
+    if (s_thread_hdl == NULL) {
+        XF_LOGE(TAG, "xf_osal_thread_create error");
+        return;
+    }
+}
+
+/* ==================== [Static Functions] ================================== */
+
+static void _example_thread(void *argument)
+{
+    UNUSED(argument);
+
+    ex_easy_wifi_ap();
+
+    char rx_buffer[128];
+    int addr_family = 0;
+    int ip_protocol = 0;
+    int sockfd = 0;
+
+    struct sockaddr_in dest_addr = {0};
+    struct sockaddr_in source_addr = {0};
+    struct timeval timeout = {0};
+
+    dest_addr.sin_addr.s_addr   = htonl(CLIENT_IP_ADDR);
+    dest_addr.sin_family        = AF_INET;
+    dest_addr.sin_port          = htons(PORT);
+    addr_family                 = AF_INET;
+    ip_protocol                 = IPPROTO_IP;
+
+    sockfd = socket(addr_family, SOCK_DGRAM, ip_protocol);
+    if (sockfd < 0) {
+        XF_LOGE(TAG, "Unable to create socket: errno %d", errno);
+        goto l_err;
+    }
+    XF_LOGI(TAG, "Socket created");
+
+    /* 设置接收超时时间 */
+    timeout.tv_sec = 10;
+    timeout.tv_usec = 0;
+    setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+    /* 绑定端口号 */
+    int err = bind(sockfd, (struct sockaddr *)&dest_addr, sizeof(dest_addr));
+    if (err < 0) {
+        XF_LOGE(TAG, "Socket unable to bind: errno %d", errno);
+        goto l_err;
+    }
+    XF_LOGI(TAG, "Socket bound, port %d", PORT);
+
+    for (;;) {
+        xf_osal_delay_ms(EXAMPLE_DELAY_MS);
+
+        XF_LOGI(TAG, "Waiting for data.");
+
+        socklen_t socklen = sizeof(source_addr);
+        int len = recvfrom(sockfd,
+                           rx_buffer, sizeof(rx_buffer) - 1, 0,
+                           (struct sockaddr *)&source_addr, &socklen);
+        if (len < 0) {
+            XF_LOGE(TAG, "recvfrom failed: errno %d", errno);
+            continue;
+        }
+
+        /* 获取来源地址 */
+        xf_ip4_addr_t src_ip4 = {0};
+        src_ip4.addr = source_addr.sin_addr.s_addr;
+
+        rx_buffer[len] = 0;
+        XF_LOGI(TAG, "Received %d bytes from " XF_IPSTR ":",
+                len, XF_IP2STR(&src_ip4));
+        XF_LOGI(TAG, "%s", rx_buffer);
+
+        /* 发送 */
+        int err = sendto(sockfd,
+                         payload, strlen(payload), 0,
+                         (struct sockaddr *)&source_addr, sizeof(source_addr));
+        if (err < 0) {
+            XF_LOGE(TAG, "Error occurred during sending: errno %d", errno);
+            break;
+        }
+    }
+
+l_err:;
+    if (sockfd != -1) {
+        XF_LOGE(TAG, "Shutting down socket...");
+        shutdown(sockfd, 0);
+        closesocket(sockfd);
+    }
+    xf_osal_thread_delete(NULL);
+}

--- a/examples/protocols/sockets/udp_server/xf_project.py
+++ b/examples/protocols/sockets/udp_server/xf_project.py
@@ -1,0 +1,11 @@
+import xf_build
+from xf_build import api
+from pathlib import Path
+
+example_components_path: Path = api.XF_ROOT / "examples" / "example_components"
+
+example_components = []
+example_components.append((example_components_path / "ex_easy_wifi").as_posix())
+
+xf_build.project_init(user_dirs=example_components)
+xf_build.program()

--- a/ports/espressif/esp32/port_xf_netif.c
+++ b/ports/espressif/esp32/port_xf_netif.c
@@ -214,6 +214,11 @@ xf_err_t xf_netif_dhcps_get_clients_by_mac(
                  (int)pair_array_size, (esp_netif_pair_mac_ip_t *)mac_ip_pair_array);
     xf_ret = port_convert_pf2xf_err(pf_err);
 
+    /* esp_netif_dhcps_get_clients_by_mac 传出的 ip 可能已经转换，此处转回去 */
+    for (size_t i = 0; i < pair_array_size; i++) {
+        mac_ip_pair_array[i].ip.addr = esp_netif_htonl(mac_ip_pair_array[i].ip.addr);
+    }
+
     return xf_ret;
 }
 


### PR DESCRIPTION
# 简述

新增网络相关示例：
```
📦protocols
 ┣ 📂http_request
 ┣ 📂icmp_echo
 ┣ 📂iperf
 ┃ ┣ 📂softap
 ┃ ┗ 📂station
 ┗ 📂sockets
   ┣ 📂tcp_client
   ┣ 📂tcp_server
   ┣ 📂udp_client
   ┗ 📂udp_server
```

已测试ipv4，暂未测试ipv6，测试结果见对应示例readme中的日志。

# todo

由于ws63没有开启LWIP_POSIX_SOCKETS_IO_NAMES，因此不使用`close()`关闭socket，而是使用`closesocket()`关闭socket；而esp32使用`close()`或`closesocket()`都可以关闭socket。

因此目前上传的版本均使用`closesocket()`来关闭socket。

具体是否需要开启LWIP_POSIX_SOCKETS_IO_NAMES使所有平台均使用posix接口操作socket需进一步讨论。
