### PR TITLE
✨ feat(plugins): 添加cflags支持

### DIFF
--- a/plugins/bs21/cmake_project.j2
+++ b/plugins/bs21/cmake_project.j2
@@ -45,5 +45,15 @@ set(XF_SRCS_STR
     {%- endfor %}
 )
 
+{# TODO 目前 sdk 中的 xf_app 包含所有 xfusion 源码，共用 cflags, 暂不能每个组件单独配置 cflags #}
+set(XF_CFLAGS_STR
+    {%- for key, cmpnt in user_components.items() %}    {# user_components #}
+        {%- for cflag in cmpnt.cflags %}
+    {{cflag}}
+        {%- endfor %}
+    {%- endfor %}
+)
+
 list(REMOVE_DUPLICATES XF_INCS_STR)
 list(REMOVE_DUPLICATES XF_SRCS_STR)
+list(REMOVE_DUPLICATES XF_CFLAGS_STR)

--- a/plugins/esp32/components.j2
+++ b/plugins/esp32/components.j2
@@ -5,3 +5,8 @@ idf_component_register(
     WHOLE_ARCHIVE
 )
 
+{% if cflags|default([]) %}
+target_compile_options(${COMPONENT_LIB} PRIVATE 
+    {% for cflag in cflags %} "{{cflag}}" {% endfor %}
+)
+{% endif %}

--- a/plugins/ws63/cmake_project.j2
+++ b/plugins/ws63/cmake_project.j2
@@ -45,5 +45,15 @@ set(XF_SRCS_STR
     {%- endfor %}
 )
 
+{# TODO 目前 sdk 中的 xf_app 包含所有 xfusion 源码，共用 cflags, 暂不能每个组件单独配置 cflags #}
+set(XF_CFLAGS_STR
+    {%- for key, cmpnt in user_components.items() %}    {# user_components #}
+        {%- for cflag in cmpnt.cflags %}
+    {{cflag}}
+        {%- endfor %}
+    {%- endfor %}
+)
+
 list(REMOVE_DUPLICATES XF_INCS_STR)
 list(REMOVE_DUPLICATES XF_SRCS_STR)
+list(REMOVE_DUPLICATES XF_CFLAGS_STR)


### PR DESCRIPTION
jinja2模板中添加了cflags。

对esp32，从xf组件生成的每个idf组件，使用对应xf组件中的cflags；而对ws63和bs21，从xf组件生成的sdk组件，共用所有xf组件中的cflags。

由于ws63和bs21的sdk中，添加sdk组件必须修改python配置文件，因此在xf到对应sdk的对接中，将所有xf组件源码加入到一个名为xf_app的sdk组件，因此编译"各个xf组件"时不能使用单独的cflags。
