### PR TITLE
🎈 perf(xf_iperf,xf_ping): 提升安全性

### DIFF
--- a/components/xf_nal/xf_netif/xf_netif_ip_addr_types.h
+++ b/components/xf_nal/xf_netif/xf_netif_ip_addr_types.h
@@ -63,6 +63,27 @@ extern "C" {
     xf_ip4_addr3_16(ipaddr), \
     xf_ip4_addr4_16(ipaddr)
 
+#define XF_IP6_ADDR_BLOCK1(ip6addr) ((uint16_t)((xf_netif_htonl((ip6addr)->addr[0]) >> 16) & 0xffff))
+#define XF_IP6_ADDR_BLOCK2(ip6addr) ((uint16_t)((xf_netif_htonl((ip6addr)->addr[0])) & 0xffff))
+#define XF_IP6_ADDR_BLOCK3(ip6addr) ((uint16_t)((xf_netif_htonl((ip6addr)->addr[1]) >> 16) & 0xffff))
+#define XF_IP6_ADDR_BLOCK4(ip6addr) ((uint16_t)((xf_netif_htonl((ip6addr)->addr[1])) & 0xffff))
+#define XF_IP6_ADDR_BLOCK5(ip6addr) ((uint16_t)((xf_netif_htonl((ip6addr)->addr[2]) >> 16) & 0xffff))
+#define XF_IP6_ADDR_BLOCK6(ip6addr) ((uint16_t)((xf_netif_htonl((ip6addr)->addr[2])) & 0xffff))
+#define XF_IP6_ADDR_BLOCK7(ip6addr) ((uint16_t)((xf_netif_htonl((ip6addr)->addr[3]) >> 16) & 0xffff))
+#define XF_IP6_ADDR_BLOCK8(ip6addr) ((uint16_t)((xf_netif_htonl((ip6addr)->addr[3])) & 0xffff))
+
+#define XF_IPV6STR "%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x"
+
+#define XF_IPV62STR(ipaddr) \
+    XF_IP6_ADDR_BLOCK1(&(ipaddr)), \
+    XF_IP6_ADDR_BLOCK2(&(ipaddr)), \
+    XF_IP6_ADDR_BLOCK3(&(ipaddr)), \
+    XF_IP6_ADDR_BLOCK4(&(ipaddr)), \
+    XF_IP6_ADDR_BLOCK5(&(ipaddr)), \
+    XF_IP6_ADDR_BLOCK6(&(ipaddr)), \
+    XF_IP6_ADDR_BLOCK7(&(ipaddr)), \
+    XF_IP6_ADDR_BLOCK8(&(ipaddr))
+
 #define XF_IPADDR_TYPE_V4                0U
 #define XF_IPADDR_TYPE_V6                6U
 #define XF_IPADDR_TYPE_ANY               46U

--- a/components/xf_nal/xf_netif/xf_netif_types.h
+++ b/components/xf_nal/xf_netif/xf_netif_types.h
@@ -69,7 +69,7 @@ typedef enum _xf_netif_dns_type_t {
  * @brief DNS 服务器信息。
  */
 typedef struct _xf_netif_dns_info_t {
-    xf_ip_addr_t ip; /*!< DNS 服务器的 IPV4 地址 */
+    xf_ip_addr_t ip; /*!< DNS 服务器地址 */
 } xf_netif_dns_info_t;
 
 /**

--- a/components/xf_net_apps/XFKconfig
+++ b/components/xf_net_apps/XFKconfig
@@ -15,5 +15,9 @@ menu "xf_net_apps Configuration"
         default y
         depends on XF_NET_APPS_ENABLE
 
+    config XF_NET_APPS_ENABLE_IPV6
+        bool "Enable IPv6."
+        default y
+    
 endmenu # xf_net_apps Configuration
   

--- a/components/xf_net_apps/xf_iperf/xf_iperf.c
+++ b/components/xf_net_apps/xf_iperf/xf_iperf.c
@@ -648,7 +648,7 @@ static void iperf_task_traffic(void *arg)
 static uint32_t iperf_get_buffer_len(void)
 {
     if (iperf_is_udp_client()) {
-#ifdef CONFIG_LWIP_IPV6
+#ifdef CONFIG_XF_NET_APPS_ENABLE_IPV6
         if (s_ctx.cfg.len_send_buf) {
             return s_ctx.cfg.len_send_buf;
         } else if (s_ctx.cfg.type == IPERF_IP_TYPE_IPV6) {

--- a/components/xf_net_apps/xf_iperf/xf_iperf.h
+++ b/components/xf_net_apps/xf_iperf/xf_iperf.h
@@ -149,8 +149,8 @@ typedef struct _xf_iperf_cfg_t {
  */
 #define XF_IPERF_DEFAULT_CONFIG() (xf_iperf_cfg_t) { \
         .flag = 0, \
-        .dip = {0}, \
-        .sip = {0}, \
+        .dip = {}, \
+        .sip = {}, \
         .type = IPERF_IP_TYPE_IPV4, \
         .dport = IPERF_DEFAULT_PORT, \
         .sport = IPERF_DEFAULT_PORT, \

--- a/components/xf_net_apps/xf_iperf/xf_iperf.h
+++ b/components/xf_net_apps/xf_iperf/xf_iperf.h
@@ -25,6 +25,7 @@
 
 #include "xf_utils.h"
 #include "xf_osal.h"
+#include "xf_netif.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,14 +123,8 @@ typedef struct _xf_iperf_cfg_t {
     uint32_t flag;                  /*!< 设定客户端或服务端/协议的标志，
                                      *   见 @ref IPERF_FLAG_CLIENT, @ref IPERF_FLAG_TCP.
                                      */
-    union {
-        uint32_t destination_ip4;   /*!< 目标 ipv4 地址。 */
-        char    *destination_ip6;   /*!< 目标 ipv6 地址。 */
-    };
-    union {
-        uint32_t source_ip4;        /*!< 源 ipv4 地址。 */
-        char    *source_ip6;        /*!< 源 ipv6 地址。 */
-    };
+    xf_ip_addr_t dip;               /*!< 目标地址。 */
+    xf_ip_addr_t sip;               /*!< 源地址。 TODO 不支持 IPv6 */
     uint8_t type;                   /*!< 源和目标的地址类型。 */
     uint16_t dport;                 /*!< 目标端口。 */
     uint16_t sport;                 /*!< 源端口。 */
@@ -154,8 +149,8 @@ typedef struct _xf_iperf_cfg_t {
  */
 #define XF_IPERF_DEFAULT_CONFIG() (xf_iperf_cfg_t) { \
         .flag = 0, \
-        .destination_ip4 = 0, \
-        .source_ip4 = 0, \
+        .dip = {0}, \
+        .sip = {0}, \
         .type = IPERF_IP_TYPE_IPV4, \
         .dport = IPERF_DEFAULT_PORT, \
         .sport = IPERF_DEFAULT_PORT, \

--- a/components/xf_net_apps/xf_ping/xf_ping.c
+++ b/components/xf_net_apps/xf_ping/xf_ping.c
@@ -121,13 +121,13 @@ xf_err_t xf_ping_new_session(
 
     /* 创建 socket */
     if (IP_IS_V4(&p_cfg->target_addr)
-#if CONFIG_LWIP_IPV6
+#if CONFIG_XF_NET_APPS_ENABLE_IPV6
             || ip6_addr_isipv4mappedipv6(ip_2_ip6(&p_cfg->target_addr))
 #endif
        ) {
         ctx->sock = socket(AF_INET, SOCK_RAW, IP_PROTO_ICMP);
     }
-#if CONFIG_LWIP_IPV6
+#if CONFIG_XF_NET_APPS_ENABLE_IPV6
     else {
         ctx->sock = socket(AF_INET6, SOCK_RAW, IP6_NEXTH_ICMP6);
     }
@@ -161,7 +161,7 @@ xf_err_t xf_ping_new_session(
         inet_addr_from_ip4addr(&to4->sin_addr, ip_2_ip4(&p_cfg->target_addr));
         ctx->packet_hdr->type = ICMP_ECHO;
     }
-#if CONFIG_LWIP_IPV6
+#if CONFIG_XF_NET_APPS_ENABLE_IPV6
     if (IP_IS_V6(&p_cfg->target_addr)) {
         struct sockaddr_in6 *to6 = (struct sockaddr_in6 *)&ctx->target_addr;
         to6->sin6_family = AF_INET6;
@@ -309,7 +309,7 @@ static int xf_ping_receive(xf_ping_ctx_t *ctx)
             IP_SET_TYPE_VAL(ctx->recv_addr, IPADDR_TYPE_V4);
             data_head = (uint16_t)(sizeof(struct ip_hdr) + sizeof(struct icmp_echo_hdr));
         }
-#if CONFIG_LWIP_IPV6
+#if CONFIG_XF_NET_APPS_ENABLE_IPV6
         else {
             // IPv6
             struct sockaddr_in6 *from6 = (struct sockaddr_in6 *)&from;
@@ -330,7 +330,7 @@ static int xf_ping_receive(xf_ping_ctx_t *ctx)
                     return len;
                 }
             }
-#if CONFIG_LWIP_IPV6
+#if CONFIG_XF_NET_APPS_ENABLE_IPV6
             else if (IP_IS_V6_VAL(ctx->recv_addr)) {
                 struct ip6_hdr *iphdr = (struct ip6_hdr *)buf;
                 struct icmp6_echo_hdr *iecho6 = (struct icmp6_echo_hdr *)(buf + sizeof(struct ip6_hdr)); /*!< IPv6 头长度为 40 */

--- a/components/xf_net_apps/xf_ping/xf_ping.h
+++ b/components/xf_net_apps/xf_ping/xf_ping.h
@@ -48,13 +48,29 @@ typedef struct _xf_ping_cfg_t {
     uint32_t interval_ms;       /*!< 每两个 ping 的间隔时间(单位 ms)。 */
     uint32_t timeout_ms;        /*!< 每次 ping 的超时时间(单位 ms)。 */
     uint32_t data_size;         /*!< ICMP 数据包标头旁边的数据大小。 */
-    int tos;                    /*!< 服务类型，IP 标头中指定的字段。 */
-    int ttl;                    /*!< 生存时间，IP 标头中指定的字段。 */
+    uint8_t tos;                /*!< 服务类型，IP 标头中指定的字段。 */
+    uint8_t ttl;                /*!< 生存时间，IP 标头中指定的字段。 */
     ip_addr_t target_addr;      /*!< 目标 IP 地址，IPv4 或 IPv6。 */
     uint32_t task_stack_size;   /*!< 内部 ping 任务的堆栈大小。 */
     uint32_t task_prio;         /*!< 内部 ping 任务的优先级。 */
     uint32_t interface;         /*!< Netif 索引，interface=0 表示 NETIF_NO_INDEX。 */
+    uint8_t auto_delete_flag;   /*!< XF_PING_EVENT_END 事件发生后，是否自动删除会话。 */
 } xf_ping_cfg_t;
+
+/**
+ * @brief ping 更新配置标志。
+ */
+typedef struct _xf_ping_cfg_update_flags_t {
+    uint32_t b_count            : 1;    /*!< 更新 ping 次数。 */
+    uint32_t b_interval_ms      : 1;    /*!< 更新间隔时间。 */
+    uint32_t b_timeout_ms       : 1;    /*!< 更新超时时间。 */
+    uint32_t b_tos              : 1;    /*!< 更新服务类型。 */
+    uint32_t b_ttl              : 1;    /*!< 更新生存时间。 */
+    uint32_t b_target_addr      : 1;    /*!< 更新目标 IP 地址。 */
+    uint32_t b_interface        : 1;    /*!< 更新 Netif 索引。 */
+    uint32_t b_auto_delete_flag : 1;    /*!< 更新是否自动删除会话。 */
+    uint32_t reserve            : 24;   /*!< 保留位。 */
+} xf_ping_cfg_update_flags_t;
 
 /**
  * @brief 默认 ping 配置
@@ -70,15 +86,29 @@ typedef struct _xf_ping_cfg_t {
         .task_stack_size = (4 * 1024), \
         .task_prio = XF_OSAL_PRIORITY_NORMOL, \
         .interface = 0, \
+        .auto_delete_flag = 0, \
     }
 
 /**
  * @brief Ping 事件声明。
+ *
+ * @attention
+ *      1.  注意，出于安全性考虑，禁止在回调中删除会话。
+ *      2.  如果需要一次性 ping 会话，请设置 `<xf_ping_cfg_t>.auto_delete_flag = true`.
+ *          将会在运行一次结束后，内部 task 自动删除 ping 会话。
+ *          此时注意通过 `XF_PING_EVENT_DELETE` 事件将 `xf_ping_new_session()` 传出的句柄
+ *          置为空指针，防止野指针。
+ *          设置了 `<xf_ping_cfg_t>.auto_delete_flag = true` 后，不需要再调用
+ *          `xf_ping_delete_session()`。
+ *      3.  如果 `<xf_ping_cfg_t>.auto_delete_flag = false`，
+ *          当一个 ping 会话不再需要后，请通过 `xf_ping_delete_session()` 删除会话，
+ *          并将外部保存的句柄置为 NULL。
  */
 typedef enum _xf_ping_event_code_t {
     XF_PING_EVENT_SUCC = 0x00,          /*!< 收到 ICMP 应答数据包。 */
     XF_PING_EVENT_TIMEOUT,              /*!< ICMP 应答数据包超时。 */
     XF_PING_EVENT_END,                  /*!< ping 会话完成。 */
+    XF_PING_EVENT_DELETE,               /*!< ping 会话已删除。 */
 
     XF_PING_EVENT_MAX,                  /*!< ping 事件 ID 最大值，无效 ID。 */
 } xf_ping_event_code_t;
@@ -117,6 +147,7 @@ typedef struct _xf_ping_ctx_t {
     uint32_t received;                  /*!< 收到的回复数据包数量。 */
     uint8_t ttl;                        /*!< ping 生存时间。 */
     uint8_t tos;                        /*!< ping 服务类型。 */
+    uint8_t auto_delete_flag;           /*!< XF_PING_EVENT_END 事件发生后，是否自动删除会话。 */
 
     /* privte: */
     int sock;                           /*!< socket 文件描述符。 */
@@ -179,6 +210,20 @@ xf_err_t xf_ping_delete_session(xf_ping_t hdl);
  *      - XF_OK 成功
  */
 xf_err_t xf_ping_start(xf_ping_t hdl);
+
+/**
+ * @brief 重新启动 ping 会话。
+ *
+ * @param hdl ping 会话句柄
+ * @param p_cfg 需要更新的 ping 配置，为 NULL 时跳过更新配置。
+ * @param p_flags ping 配置中需要更新的部分。
+ * @return
+ *      - XF_ERR_INVALID_ARG 无效参数
+ *      - XF_ERR_BUSY ping 会话正在运行，无法重新开始
+ *      - XF_OK 成功
+ */
+xf_err_t xf_ping_restart(
+    xf_ping_t hdl, const xf_ping_cfg_t *p_cfg, xf_ping_cfg_update_flags_t *p_flags);
 
 /**
  * @brief 检查 ping 是否正在运行。

--- a/examples/example_components/ex_easy_wifi/ex_easy_wifi.c
+++ b/examples/example_components/ex_easy_wifi/ex_easy_wifi.c
@@ -153,7 +153,7 @@ xf_ip4_addr_t ex_easy_wifi_ap_get_last_sta_ip(void)
         XF_LOGE(TAG, "xf_netif_dhcps_get_clients_by_mac-%s", xf_err_to_name(xf_ret));
         goto l_err;
     }
-    ip4_addr.addr = xf_netif_htonl(pair_mac_ip[0].ip.addr);
+    ip4_addr.addr = pair_mac_ip[0].ip.addr;
     return ip4_addr;
 
 l_err:;

--- a/examples/protocols/iperf/softap/main/xf_main.c
+++ b/examples/protocols/iperf/softap/main/xf_main.c
@@ -102,8 +102,8 @@ static void _example_thread(void *argument)
         xf_iperf_cfg_t cfg  = XF_IPERF_DEFAULT_CONFIG();
         cfg.type            = IPERF_IP_TYPE_IPV4;
         cfg.time            = CONFIG_EXAMPLE_IPERF_TIME;
-        cfg.destination_ip4 = dest_ip4.addr;
-        cfg.source_ip4      = src_ip4.addr;
+        cfg.dip.u_addr.ip4.addr = dest_ip4.addr;
+        cfg.sip.u_addr.ip4.addr = src_ip4.addr;
 
 #ifdef CONFIG_EXAMPLE_IPERF_AUTO_TEST
         if (s_iperf_test_item[test_idx] & IPERF_FLAG_CLIENT) {
@@ -125,15 +125,14 @@ static void _example_thread(void *argument)
 #endif /* CONFIG_EXAMPLE_IPERF_AUTO_TEST */
 
         XF_LOGI(TAG,
-                "mode=%s-%s sip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
-                "dip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
+                "mode=%s-%s "
+                "sip=" XF_IPSTR ":%d,"
+                "dip=" XF_IPSTR ":%d,"
                 "interval=%" PRId32 ", time=%" PRId32 "",
                 cfg.flag & IPERF_FLAG_TCP ? "tcp" : "udp",
                 cfg.flag & IPERF_FLAG_SERVER ? "server" : "client",
-                cfg.source_ip4 & 0xFF, (cfg.source_ip4 >> 8) & 0xFF, (cfg.source_ip4 >> 16) & 0xFF,
-                (cfg.source_ip4 >> 24) & 0xFF, cfg.sport,
-                cfg.destination_ip4 & 0xFF, (cfg.destination_ip4 >> 8) & 0xFF,
-                (cfg.destination_ip4 >> 16) & 0xFF, (cfg.destination_ip4 >> 24) & 0xFF, cfg.dport,
+                XF_IP2STR(&cfg.sip.u_addr.ip4), (int)cfg.sport,
+                XF_IP2STR(&cfg.dip.u_addr.ip4), (int)cfg.dport, 
                 cfg.interval, cfg.time);
 
         xf_iperf_start(&cfg, NULL, NULL);

--- a/examples/protocols/iperf/station/main/xf_main.c
+++ b/examples/protocols/iperf/station/main/xf_main.c
@@ -102,8 +102,8 @@ static void _example_thread(void *argument)
         xf_iperf_cfg_t cfg  = XF_IPERF_DEFAULT_CONFIG();
         cfg.type            = IPERF_IP_TYPE_IPV4;
         cfg.time            = CONFIG_EXAMPLE_IPERF_TIME;
-        cfg.destination_ip4 = dest_ip4.addr;
-        cfg.source_ip4      = src_ip4.addr;
+        cfg.dip.u_addr.ip4.addr = dest_ip4.addr;
+        cfg.sip.u_addr.ip4.addr = src_ip4.addr;
 
 #ifdef CONFIG_EXAMPLE_IPERF_AUTO_TEST
         if (s_iperf_test_item[test_idx] & IPERF_FLAG_CLIENT) {
@@ -125,15 +125,14 @@ static void _example_thread(void *argument)
 #endif /* CONFIG_EXAMPLE_IPERF_AUTO_TEST */
 
         XF_LOGI(TAG,
-                "mode=%s-%s sip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
-                "dip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
+                "mode=%s-%s "
+                "sip=" XF_IPSTR ":%d,"
+                "dip=" XF_IPSTR ":%d,"
                 "interval=%" PRId32 ", time=%" PRId32 "",
                 cfg.flag & IPERF_FLAG_TCP ? "tcp" : "udp",
                 cfg.flag & IPERF_FLAG_SERVER ? "server" : "client",
-                cfg.source_ip4 & 0xFF, (cfg.source_ip4 >> 8) & 0xFF, (cfg.source_ip4 >> 16) & 0xFF,
-                (cfg.source_ip4 >> 24) & 0xFF, cfg.sport,
-                cfg.destination_ip4 & 0xFF, (cfg.destination_ip4 >> 8) & 0xFF,
-                (cfg.destination_ip4 >> 16) & 0xFF, (cfg.destination_ip4 >> 24) & 0xFF, cfg.dport,
+                XF_IP2STR(&cfg.sip.u_addr.ip4), (int)cfg.sport,
+                XF_IP2STR(&cfg.dip.u_addr.ip4), (int)cfg.dport, 
                 cfg.interval, cfg.time);
 
         xf_iperf_start(&cfg, NULL, NULL);


### PR DESCRIPTION
1. xf_ping添加一次性会话选项，结束则自动删除任务。
1. 原xf_iperf对ipv6仅拷贝指针；现改为完全拷贝地址。
1. 新增ipv6相关宏。

已通过at验证ping和iperf；已测试iperf例程。均正常。