### PR TITLE
🦄 refactor(nearlink): 分离port

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "components/xf_sle/xf_sle"]
 	path = components/xf_sle/xf_sle
 	url = https://github.com/x-eks-fusion/xf_sle.git
+[submodule "ports/nearlink/port_xf_for_nearlink"]
+	path = ports/nearlink/port_xf_for_nearlink
+	url = https://github.com/x-eks-fusion/port_xf_for_nearlink.git

--- a/boards/nearlink/bs21/XFKconfig
+++ b/boards/nearlink/bs21/XFKconfig
@@ -6,45 +6,34 @@ menu "Platform Config"
             bool "bs2x sdk public version"
          config BS2X_1_0_13_INTERNAL
             bool "bs2x sdk internal version, 1.0.13"
+         config BS2X_1_0_15_INTERNAL
+            bool "bs2x sdk internal version, 1.0.15"
     endchoice
     
     config PLATFORM_SDK_RELATIVE_PATH
         string
         default "sdks/bs2x_sdk" if BS2X_SDK
         default "sdks/bs2x_1.0.13_internal" if BS2X_1_0_13_INTERNAL
+        default "sdks/bs2x_1.0.15_internal" if BS2X_1_0_15_INTERNAL
 
-    if BS2X_SDK
+    choice 
+        bool "sdk default target"
+        help
+            Not every target is available in all SDKS.
+        default STANDARD_BS21E_1100E
+        config BS21E_SLE_BLE_SLP_CENTRAL_PERIPHERAL
+            bool "bs21e-sle-ble-slp-central-peripheral"
+        config STANDARD_BS21_N1100
+            bool "standard-bs21-n1100"
+        config STANDARD_BS21E_1100E
+            bool "standard-bs21e-1100e"
+    endchoice 
 
-        choice 
-            bool "sdk default target"
-            default BS21E_SLE_BLE_SLP_CENTRAL_PERIPHERAL
-            config BS21E_SLE_BLE_SLP_CENTRAL_PERIPHERAL
-                bool "bs21e-sle-ble-slp-central-peripheral"
-        endchoice 
-
-        config PLATFORM_SDK_DEFAULT_TARGET
-            string
-            default "bs21e-sle-ble-slp-central-peripheral" if BS21E_SLE_BLE_SLP_CENTRAL_PERIPHERAL
-
-    endif
-
-    if BS2X_1_0_13_INTERNAL
-    
-        choice
-            bool "sdk default target"
-            default STANDARD_BS21E_1100E
-            config STANDARD_BS21_N1100
-                bool "standard-bs21-n1100"
-            config STANDARD_BS21E_1100E
-                bool "standard-bs21e-1100e"
-        endchoice 
-
-        config PLATFORM_SDK_DEFAULT_TARGET
-            string
-            default "standard-bs21-n1100" if STANDARD_BS21_N1100
-            default "standard-bs21e-1100e" if STANDARD_BS21E_1100E
-
-    endif
+    config PLATFORM_SDK_DEFAULT_TARGET
+        string
+        default "bs21e-sle-ble-slp-central-peripheral" if BS21E_SLE_BLE_SLP_CENTRAL_PERIPHERAL
+        default "standard-bs21-n1100" if STANDARD_BS21_N1100
+        default "standard-bs21e-1100e" if STANDARD_BS21E_1100E
 
     # 预配置均为默认情况下不会在菜单界面显示，仅在开启调试或者源码中可被查看、修改
     menu "pre-config"   

--- a/boards/nearlink/bs21/target.json
+++ b/boards/nearlink/bs21/target.json
@@ -1,8 +1,8 @@
 {
     "sdks":{
         "url": "https://github.com/Im-eks-dev/bs2x_sdk", 
-        "commit": "11f30ec4f4c06d2d75420bdcfcad83de01031301",
+        "commit": "a14b06ac857b699334356aeb78a73ba7c59ed5b4",
         "dir": "bs2x_sdk",
-        "branch": "main"
+        "branch": "bs2x_1.10.15/v2.0"
     }
 }

--- a/boards/nearlink/ws63/target.json
+++ b/boards/nearlink/ws63/target.json
@@ -1,8 +1,8 @@
 {
     "sdks":{
         "url": "https://github.com/x-eks-fusion/fbb_ws63",
-        "commit": "f0fbaef71197650e7a25695bb814e8fadca511ba",
+        "commit": "e3d715424b5d5787f4c918dcba53ae64e1b4dec4",
         "dir": "fbb_ws63",
-        "branch": "master"
+        "branch": "ws63_1.10.102/v2.0"
     }
 }

--- a/plugins/bs21/cmake_project.j2
+++ b/plugins/bs21/cmake_project.j2
@@ -22,6 +22,11 @@ set(XF_INCS_STR
     {{inc_dir}}
         {%- endfor %}
     {%- endfor %}
+    {%- for key, port in public_port.items() %}  {# public_port #}
+        {%- for inc_dir in port.inc_dirs %}
+    {{inc_dir}}
+        {%- endfor %}
+    {%- endfor %}
 )
 
 set(XF_SRCS_STR
@@ -40,6 +45,11 @@ set(XF_SRCS_STR
     {%- endfor %}
     {%- for key, cmpnt in user_dirs.items() %}    {# user_dirs #}
         {%- for src in cmpnt.srcs %}
+    {{src}}
+        {%- endfor %}
+    {%- endfor %}
+    {%- for key, port in public_port.items() %}    {# public_port #}
+        {%- for src in port.srcs %}
     {{src}}
         {%- endfor %}
     {%- endfor %}

--- a/plugins/ws63/cmake_project.j2
+++ b/plugins/ws63/cmake_project.j2
@@ -22,6 +22,11 @@ set(XF_INCS_STR
     {{inc_dir}}
         {%- endfor %}
     {%- endfor %}
+    {%- for key, port in public_port.items() %}  {# public_port #}
+        {%- for inc_dir in port.inc_dirs %}
+    {{inc_dir}}
+        {%- endfor %}
+    {%- endfor %}
 )
 
 set(XF_SRCS_STR
@@ -40,6 +45,11 @@ set(XF_SRCS_STR
     {%- endfor %}
     {%- for key, cmpnt in user_dirs.items() %}    {# user_dirs #}
         {%- for src in cmpnt.srcs %}
+    {{src}}
+        {%- endfor %}
+    {%- endfor %}
+    {%- for key, port in public_port.items() %}    {# public_port #}
+        {%- for src in port.srcs %}
     {{src}}
         {%- endfor %}
     {%- endfor %}

--- a/ports/nearlink/bs21/README.md
+++ b/ports/nearlink/bs21/README.md
@@ -1,3 +1,3 @@
 # README
 
-对接 xfusion 部分不在此处.
+为了与 XFusion 减少耦合， nearlink 系列芯片对接 XFusion 的代码不在此处. 见 `ports/nearlink/port_xf_for_nearlink`.

--- a/ports/nearlink/bs21/XFKconfig
+++ b/ports/nearlink/bs21/XFKconfig
@@ -1,0 +1,5 @@
+menu "Ports Config"
+
+    orsource "../port_xf_for_nearlink/bs21/XFKconfig"
+
+endmenu # "Ports Config"

--- a/ports/nearlink/bs21/xf_collect.py
+++ b/ports/nearlink/bs21/xf_collect.py
@@ -1,3 +1,32 @@
+import os
+import sys
 import xf_build
+from xf_build import api
 
-xf_build.collect()
+PORT_REL_PATH = os.path.join("..", "port_xf_for_nearlink") 
+
+# 获取 ports/nearlink/port_xf_for_nearlink/port_xf_collect.py 所在目录
+RELATIVE_TARGET = api.XF_TARGET_PATH.relative_to(api.XF_ROOT / "boards")
+ROOT_PORT = api.XF_ROOT / "ports" / RELATIVE_TARGET
+port_dir = (ROOT_PORT / PORT_REL_PATH).resolve().as_posix()
+sys.path.insert(0, port_dir)
+
+# 加载获取构建文件列表方法
+try:
+    from port_xf_collect import get_target_build_lists
+except ImportError:
+    raise ImportError("无法加载 port_xf_collect 脚本")
+
+# 获取构建文件列表
+try:
+    current_target = os.path.basename(api.XF_TARGET_PATH)
+    lists = get_target_build_lists(target=current_target, port_rel_path=PORT_REL_PATH)
+except Exception as e:
+    raise RuntimeError(f"配置加载失败: {str(e)}")
+
+xf_build.collect(
+    srcs=lists["srcs"],
+    inc_dirs=lists["incs"],
+    requires=lists["reqs"],
+    cflags=lists["cflags"]
+)

--- a/ports/nearlink/ws63/README.md
+++ b/ports/nearlink/ws63/README.md
@@ -1,3 +1,3 @@
 # README
 
-ws63 对接 xfusion 部分不在此处. 见 `sdks/fbb_ws63/src/application/ws63_porting_xf_0p2`.
+为了与 XFusion 减少耦合， nearlink 系列芯片对接 XFusion 的代码不在此处. 见 `ports/nearlink/port_xf_for_nearlink`.

--- a/ports/nearlink/ws63/XFKconfig
+++ b/ports/nearlink/ws63/XFKconfig
@@ -1,0 +1,5 @@
+menu "Ports Config"
+
+    orsource "../port_xf_for_nearlink/ws63/XFKconfig"
+
+endmenu # "Ports Config"

--- a/ports/nearlink/ws63/xf_collect.py
+++ b/ports/nearlink/ws63/xf_collect.py
@@ -1,3 +1,32 @@
+import os
+import sys
 import xf_build
+from xf_build import api
 
-xf_build.collect()
+PORT_REL_PATH = os.path.join("..", "port_xf_for_nearlink") 
+
+# 获取 ports/nearlink/port_xf_for_nearlink/port_xf_collect.py 所在目录
+RELATIVE_TARGET = api.XF_TARGET_PATH.relative_to(api.XF_ROOT / "boards")
+ROOT_PORT = api.XF_ROOT / "ports" / RELATIVE_TARGET
+port_dir = (ROOT_PORT / PORT_REL_PATH).resolve().as_posix()
+sys.path.insert(0, port_dir)
+
+# 加载获取构建文件列表方法
+try:
+    from port_xf_collect import get_target_build_lists
+except ImportError:
+    raise ImportError("无法加载 port_xf_collect 脚本")
+
+# 获取构建文件列表
+try:
+    current_target = os.path.basename(api.XF_TARGET_PATH)
+    lists = get_target_build_lists(target=current_target, port_rel_path=PORT_REL_PATH)
+except Exception as e:
+    raise RuntimeError(f"配置加载失败: {str(e)}")
+
+xf_build.collect(
+    srcs=lists["srcs"],
+    inc_dirs=lists["incs"],
+    requires=lists["reqs"],
+    cflags=lists["cflags"]
+)


### PR DESCRIPTION
注意！！！此pr要求更新对应的sdk！！！

底层sdk主要更新：

- 版本更新：
  - bs2x_sdk：11->15
  - ws63：101->102
- 星闪port：现已作为子仓库，不再跟随sdk。